### PR TITLE
Add battery monitoring, energy tracking, VE.Bus controls, and Energy setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ you need (such as AC Input Voltage L2) because they are disabled by default.
 
 ### Battery sensors
 
+- Battery State of Charge
 - Battery Voltage
 - Battery Input Current
 - Battery Output Current
 - Battery Power
+
+Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled in
+VEConfigure or VictronConnect and the connected device reports RAM variable 13 over
+the MK3 interface.
 
 ### Configuration entities
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ devices that have VE.Bus ports using the Victron Interface MK3-USB (VE.Bus to US
 This integration lets you build a remote control panel for your charger/inverter.
 
 - Sensors describe the status of your device and its electrical performance.
-- The `Remote Panel Mode` entity sets the mode to on, off, charger_only, or inverter_only.
+- The `Remote Panel Mode` entity sets the mode to on, off, pass_through, charger_only, or inverter_only.
+- The `Charge Enabled` switch preserves the inverter setting and toggles between charging modes and non-charging modes. With the inverter side enabled, turning this switch off moves the remote panel mode to `pass_through`.
+- The `Ignore AC Input State` diagnostic sensor reports whether the VE.Bus device currently indicates AC input is being ignored.
+- The `UPS Function` switch toggles the VE.Bus input wave-check behavior when that setting is available on the device.
+- The `PowerAssist` switch toggles the device's PowerAssist configuration flag when that setting is available.
+- The `Dynamic Current Limiter` switch toggles the generator-oriented current limiter configuration flag when that setting is available.
+- The `Weak AC Input` switch toggles the relaxed AC waveform acceptance flag when that setting is available.
 - The `Remote Panel Current Limit` entity sets the AC input current limit.
 - The `Remote Panel Standby` entity sets whether the device will be prevented from
   sleeping while it is turned off. Refer to the [standby mode](#standby-mode) section for more details.
@@ -18,6 +24,7 @@ This integration lets you build a remote control panel for your charger/inverter
 Here's what each remote panel switch state means:
 
 - `on`: Enable the charger and enable the inverter.
+- `pass_through`: Disable charging while keeping the inverter side enabled so AC can pass through when available.
 - `charger_only`: Enable the charger and disable the inverter.
 - `inverter_only`: Enable the inverter and disable the charger.
 - `off`: Disable the charger and disable the inverter.
@@ -63,7 +70,15 @@ Home Assistant, VEConfigure, or VictronConnect and the connected device reports 
 variable 13 over the MK3 interface.
 
 Battery Energy Into and Battery Energy Out Of are derived from the reported DC power and
-can be used with Home Assistant's Energy battery configuration.
+can be used with Home Assistant's Energy battery configuration. Their cumulative totals
+are restored after restart, and the integration can still finish loading when the VE.Bus
+device is asleep so the entities remain available and recover on a later poll.
+
+To use the energy entities in Home Assistant, open Settings -> Dashboards -> Energy ->
+Batteries and select:
+
+- Energy charged: `Battery Energy Into`
+- Energy discharged: `Battery Energy Out Of`
 
 ### Configuration entities
 
@@ -71,7 +86,12 @@ can be used with Home Assistant's Energy battery configuration.
 - Battery Capacity
 - State of Charge When Bulk Finished
 - Charge Efficiency
-- Remote Panel Mode: off, on, charging_only, inverter_only
+- Charge Enabled: off, on
+- UPS Function: off, on
+- PowerAssist: off, on
+- Dynamic Current Limiter: off, on
+- Weak AC Input: off, on
+- Remote Panel Mode: off, on, pass_through, charger_only, inverter_only
 - Remote Panel Current Limit
 - Remote Panel Standby: off, on
 
@@ -82,14 +102,23 @@ disabling Battery Monitor sets Battery Capacity to 0.
 If your device reports Charge Efficiency as a fractional value, the Home Assistant number
 entity uses that same representation. For example, `0.95` means `95%`.
 
+`Charge Enabled` acts as a focused charger toggle. Turning it off while the inverter side
+remains enabled maps the remote panel mode to `pass_through`, which keeps inverter/AC
+pass-through behavior available without charging the batteries.
+
+`UPS Function`, `PowerAssist`, `Dynamic Current Limiter`, and `Weak AC Input` mirror
+VE.Bus configuration flags when the connected device exposes them. On unsupported
+devices, those entities remain unavailable.
+
 ### Diagnostic entities
 
 - AC Input Current Limit
 - AC Input Current Limit Maximum
 - AC Input Current Limit Minimum
 - Device State: down, startup, off, slave, invert_full, invert_half, invert_aes, power_assist, bypass, state_charge
-- Front Panel Mode: off, on, charging_only
-- Actual Mode: off, on, charging_only, inverter_only
+- Front Panel Mode: off, on, charger_only
+- Ignore AC Input State: off, on
+- Actual Mode: off, on, pass_through, charger_only, inverter_only
 - Lit Indicators: mains, absorption, bulk, float, inverter, overload, low_battery, temperature
 - Blinking Indicators: mains, absorption, bulk, float, inverter, overload, low_battery, temperature
 - Firmware Version
@@ -124,6 +153,16 @@ data:
   device_id: 54b361121006d7658fa486a9ebaf02bc
   mode: "charger_only"
   current_limit: 12.5
+```
+
+Set the remote panel mode to `pass_through` to keep the inverter side enabled while
+preventing battery charging.
+
+```yaml
+action: victron_mk3.set_remote_panel_state
+data:
+  device_id: 54b361121006d7658fa486a9ebaf02bc
+  mode: "pass_through"
 ```
 
 ## Standby mode

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ you need (such as AC Input Voltage L2) because they are disabled by default.
 - Battery Input Current
 - Battery Output Current
 - Battery Power
+- Battery Charge Discharge Power
 - Battery Energy Into
 - Battery Energy Out Of
 
@@ -74,11 +75,53 @@ can be used with Home Assistant's Energy battery configuration. Their cumulative
 are restored after restart, and the integration can still finish loading when the VE.Bus
 device is asleep so the entities remain available and recover on a later poll.
 
-To use the energy entities in Home Assistant, open Settings -> Dashboards -> Energy ->
-Batteries and select:
+Battery Charge Discharge Power exposes the same DC power with the sign inverted so it can
+be used with Home Assistant's power-based battery flow view where positive values indicate
+discharge and negative values indicate charge.
+
+## Home Assistant Energy Setup
+
+Open Settings -> Dashboards -> Energy to configure the energy dashboard.
+
+### Grid settings
+
+This integration exposes `AC Input Power` as an instantaneous grid-side power sensor.
+
+- Type of power measurement: `AC Input Power`
+- Direction: `Standard`
+
+`AC Input Power` already follows Home Assistant's grid-power convention:
+
+- positive values mean importing from the grid
+- negative values mean exporting to the grid
+
+Only use `AC Input Power` for the grid power setting if the VE.Bus device is measuring the
+same grid connection point that you want Home Assistant to display. If part of the site load
+or generation bypasses the VE.Bus device, use a separate site meter for the grid settings.
+
+This integration does not currently expose cumulative grid import/export energy sensors, so
+the Energy dashboard's grid energy settings still need to come from an external meter or
+another integration when you want full grid energy accounting.
+
+### Home Battery Storage settings
+
+To configure Home Battery Storage in Home Assistant, use:
 
 - Energy charged: `Battery Energy Into`
 - Energy discharged: `Battery Energy Out Of`
+- Type of power measurement: `Battery Charge Discharge Power`
+- Direction: `Standard`
+
+`Battery Charge Discharge Power` follows Home Assistant's battery-power convention:
+
+- positive values mean the battery is discharging
+- negative values mean the battery is charging
+
+If you prefer to use `Battery Power` instead, select `Inverted` because `Battery Power`
+reports the opposite sign convention:
+
+- positive values mean charging
+- negative values mean discharging
 
 ### Configuration entities
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ you need (such as AC Input Voltage L2) because they are disabled by default.
 - Battery Output Current
 - Battery Power
 
-Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled in
-Home Assistant, VEConfigure, or VictronConnect and the connected device reports RAM
-variable 13 over the MK3 interface.
+Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled
+and the connected device reports RAM variable 13 over the MK3 interface. You can
+enable Battery Monitor directly from Home Assistant by setting Battery Capacity to a
+value greater than 0, or by enabling it in VEConfigure or VictronConnect.
 
 ### Configuration entities
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,25 @@ you need (such as AC Input Voltage L2) because they are disabled by default.
 - Battery Power
 
 Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled in
-VEConfigure or VictronConnect and the connected device reports RAM variable 13 over
-the MK3 interface.
+Home Assistant, VEConfigure, or VictronConnect and the connected device reports RAM
+variable 13 over the MK3 interface.
 
 ### Configuration entities
 
+- Battery Monitor: off, on
+- Battery Capacity
+- State of Charge When Bulk Finished
+- Charge Efficiency
 - Remote Panel Mode: off, on, charging_only, inverter_only
 - Remote Panel Current Limit
 - Remote Panel Standby: off, on
+
+The VE.Bus Battery Monitor can be enabled from Home Assistant by setting Battery Capacity
+to a value greater than 0. On devices like the one this integration was tested against,
+disabling Battery Monitor sets Battery Capacity to 0.
+
+If your device reports Charge Efficiency as a fractional value, the Home Assistant number
+entity uses that same representation. For example, `0.95` means `95%`.
 
 ### Diagnostic entities
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,15 @@ you need (such as AC Input Voltage L2) because they are disabled by default.
 - Battery Input Current
 - Battery Output Current
 - Battery Power
+- Battery Energy Into
+- Battery Energy Out Of
 
-Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled
-and the connected device reports RAM variable 13 over the MK3 interface. You can
-enable Battery Monitor directly from Home Assistant by setting Battery Capacity to a
-value greater than 0, or by enabling it in VEConfigure or VictronConnect.
+Battery State of Charge is only available when the VE.Bus Battery Monitor is enabled in
+Home Assistant, VEConfigure, or VictronConnect and the connected device reports RAM
+variable 13 over the MK3 interface.
+
+Battery Energy Into and Battery Energy Out Of are derived from the reported DC power and
+can be used with Home Assistant's Energy battery configuration.
 
 ### Configuration entities
 

--- a/custom_components/victron_mk3/__init__.py
+++ b/custom_components/victron_mk3/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from enum import Enum
 from homeassistant.components.device_automation.exceptions import DeviceNotFound
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -44,14 +43,28 @@ import voluptuous as vol
 
 from .battery_monitor import read_battery_soc, register_battery_soc_variable
 from .battery_monitor_settings import (
+    DISABLE_CHARGE_FLAG_BIT,
+    DISABLE_WAVE_CHECK_FLAG_BIT,
+    DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT,
+    FLAGS0_SETTING_ID,
+    FLAGS1_SETTING_ID,
+    MONITORED_SETTING_IDS,
+    DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT,
+    POWER_ASSIST_ENABLED_FLAG_BIT,
     BATTERY_CAPACITY_SETTING_ID,
-    BATTERY_MONITOR_SETTING_IDS,
     SettingInfo,
     SettingValue,
     battery_monitor_enabled_from_capacity,
     read_setting,
     read_setting_info,
+    setting_flag_enabled,
+    setting_flag_supported,
+    setting_raw_with_flag,
+    setting_raw_with_ups_function,
+    ups_function_supported,
+    WEAK_AC_INPUT_ENABLED_FLAG_BIT,
     write_setting,
+    write_setting_raw,
 )
 from .const import (
     AC_PHASES_POLLED,
@@ -60,16 +73,26 @@ from .const import (
     DOMAIN,
     KEY_CONTEXT,
 )
+from .remote_panel import (
+    Mode,
+    base_mode_for_remote_panel,
+    disable_charge_for_remote_panel,
+    enum_options,
+    mode_from_value,
+    mode_with_disable_charge,
+)
+from .ram_variables import (
+    IGNORE_AC_INPUT_VARIABLE_ID,
+    MONITORED_RAM_VARIABLE_IDS,
+    RamVariableInfo,
+    RamVariableValue,
+    ram_variable_bool_supported,
+    read_ram_variable,
+    read_ram_variable_info,
+)
 
 PLATFORMS: list[Platform] = ["number", "select", "sensor", "switch"]
 UPDATE_INTERVAL = timedelta(seconds=2)
-
-
-class Mode(Enum):
-    OFF = 0
-    ON = 1
-    CHARGER_ONLY = 2
-    INVERTER_ONLY = 3
 
 
 MODE_TO_SWITCH_STATE = {
@@ -78,18 +101,6 @@ MODE_TO_SWITCH_STATE = {
     Mode.CHARGER_ONLY: SwitchState.CHARGER_ONLY,
     Mode.INVERTER_ONLY: SwitchState.INVERTER_ONLY,
 }
-
-
-def enum_options(enum_class) -> List[str]:
-    return [x.lower() for x in enum_class._member_names_]
-
-
-def enum_value(e: Enum | None) -> str | None:
-    return None if e is None else str(e) if e.name is None else e.name.lower()
-
-
-def mode_from_value(value: str) -> Mode:
-    return Mode[value.upper()]
 
 
 SERVICE_NAME = "set_remote_panel_state"
@@ -112,6 +123,8 @@ class Data:
         self.dc: DCResponse | None = None
         self.led: LEDResponse | None = None
         self.power: PowerResponse | None = None
+        self.ram_variable_info: dict[int, RamVariableInfo] = {}
+        self.ram_variable_values: dict[int, RamVariableValue] = {}
         self.setting_info: dict[int, SettingInfo] = {}
         self.setting_values: dict[int, SettingValue] = {}
         self.version: VersionResponse | None = None
@@ -130,9 +143,13 @@ class Data:
         if self.config is None:
             return None
         reg = self.config.switch_register
+        charge_disabled = setting_flag_enabled(
+            self.setting_values.get(FLAGS0_SETTING_ID),
+            DISABLE_CHARGE_FLAG_BIT,
+        )
         if reg & SwitchRegister.DIRECT_REMOTE_SWITCH_CHARGE != 0:
             if reg & SwitchRegister.DIRECT_REMOTE_SWITCH_INVERT != 0:
-                return Mode.ON
+                return mode_with_disable_charge(Mode.ON, charge_disabled is True)
             else:
                 return Mode.CHARGER_ONLY
         else:
@@ -145,9 +162,13 @@ class Data:
         if self.config is None:
             return None
         reg = self.config.switch_register
+        charge_disabled = setting_flag_enabled(
+            self.setting_values.get(FLAGS0_SETTING_ID),
+            DISABLE_CHARGE_FLAG_BIT,
+        )
         if reg & SwitchRegister.SWITCH_CHARGE != 0:
             if reg & SwitchRegister.SWITCH_INVERT != 0:
-                return Mode.ON
+                return mode_with_disable_charge(Mode.ON, charge_disabled is True)
             else:
                 return Mode.CHARGER_ONLY
         else:
@@ -162,7 +183,8 @@ class Controller(Handler):
         self._mk3 = VictronMK3(port)
         self._fault: Fault | None = None
         self._idle = False
-        self._battery_monitor_info: dict[int, SettingInfo] = {}
+        self._ram_variable_info: dict[int, RamVariableInfo] = {}
+        self._setting_info: dict[int, SettingInfo] = {}
         self._last_battery_capacity: float | None = None
         self._version: VersionResponse | None = None
         self.standby: bool | None = None
@@ -222,7 +244,8 @@ class Controller(Handler):
                 else None
             )
         data.power = await self._mk3.send_power_request()
-        await self._update_battery_monitor_settings(data)
+        await self._update_settings(data)
+        await self._update_ram_variables(data)
         try:
             if data.battery_monitor_enabled:
                 data.battery_soc = await read_battery_soc(self._mk3)
@@ -234,7 +257,17 @@ class Controller(Handler):
     async def set_remote_panel_state(
         self, mode: Mode, current_limit: float | None
     ) -> None:
-        await self._mk3.send_state_request(MODE_TO_SWITCH_STATE[mode], current_limit)
+        await self._set_setting_flag(
+            FLAGS0_SETTING_ID,
+            DISABLE_CHARGE_FLAG_BIT,
+            disable_charge_for_remote_panel(mode),
+            "Charge Enabled",
+            inverted=False,
+        )
+        await self._mk3.send_state_request(
+            MODE_TO_SWITCH_STATE[base_mode_for_remote_panel(mode)],
+            current_limit,
+        )
 
     async def set_battery_monitor_enabled(self, enabled: bool) -> None:
         target_capacity = 0 if not enabled else self._last_battery_capacity
@@ -249,7 +282,7 @@ class Controller(Handler):
         )
 
     async def set_battery_monitor_setting(self, setting_id: int, value: float) -> None:
-        info = self._battery_monitor_info.get(setting_id)
+        info = await self._get_setting_info(setting_id)
         result = await write_setting(self._mk3, setting_id, value, info)
         if result is None or not result.supported:
             raise HomeAssistantError(f"Setting {setting_id} is not available")
@@ -261,14 +294,99 @@ class Controller(Handler):
         ):
             self._last_battery_capacity = result.value
 
-    async def _update_battery_monitor_settings(self, data: Data) -> None:
-        for setting_id in BATTERY_MONITOR_SETTING_IDS:
+    async def set_power_assist_enabled(self, enabled: bool) -> None:
+        await self._set_setting_flag(
+            FLAGS0_SETTING_ID,
+            POWER_ASSIST_ENABLED_FLAG_BIT,
+            enabled,
+            "PowerAssist",
+        )
+
+    async def set_ups_function_enabled(self, enabled: bool) -> None:
+        info = await self._get_setting_info(FLAGS0_SETTING_ID)
+        if not ups_function_supported(info):
+            raise HomeAssistantError("UPS Function is not available")
+
+        value = await read_setting(self._mk3, FLAGS0_SETTING_ID, info)
+        if value is None or not value.supported or value.raw_value is None:
+            raise HomeAssistantError("UPS Function is not available")
+
+        result = await write_setting_raw(
+            self._mk3,
+            FLAGS0_SETTING_ID,
+            setting_raw_with_ups_function(value.raw_value, enabled),
+            info,
+        )
+        if result is None or not result.supported:
+            raise HomeAssistantError("UPS Function is not available")
+
+    async def set_dynamic_current_limiter_enabled(self, enabled: bool) -> None:
+        await self._set_setting_flag(
+            FLAGS1_SETTING_ID,
+            DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT,
+            enabled,
+            "Dynamic Current Limiter",
+        )
+
+    async def set_weak_ac_input_enabled(self, enabled: bool) -> None:
+        await self._set_setting_flag(
+            FLAGS0_SETTING_ID,
+            WEAK_AC_INPUT_ENABLED_FLAG_BIT,
+            enabled,
+            "Weak AC Input",
+        )
+
+    async def set_ignore_ac_input_enabled(self, enabled: bool) -> None:
+        raise HomeAssistantError(
+            "Ignore AC Input is reported as state only on this device"
+        )
+
+    async def _set_setting_flag(
+        self,
+        setting_id: int,
+        flag_bit: int,
+        enabled: bool,
+        name: str,
+        *,
+        inverted: bool = False,
+    ) -> None:
+        info = await self._get_setting_info(setting_id)
+        if not setting_flag_supported(info, flag_bit):
+            raise HomeAssistantError(f"{name} is not available")
+
+        value = await read_setting(self._mk3, setting_id, info)
+        if value is None or not value.supported or value.raw_value is None:
+            raise HomeAssistantError(f"{name} is not available")
+
+        result = await write_setting_raw(
+            self._mk3,
+            setting_id,
+            setting_raw_with_flag(value.raw_value, flag_bit, not enabled if inverted else enabled),
+            info,
+        )
+        if result is None or not result.supported:
+            raise HomeAssistantError(f"{name} is not available")
+
+    async def _get_ram_variable_info(self, variable_id: int) -> RamVariableInfo | None:
+        info = self._ram_variable_info.get(variable_id)
+        if info is None:
+            info = await read_ram_variable_info(self._mk3, variable_id)
+            if info is not None:
+                self._ram_variable_info[variable_id] = info
+        return info
+
+    async def _get_setting_info(self, setting_id: int) -> SettingInfo | None:
+        info = self._setting_info.get(setting_id)
+        if info is None:
+            info = await read_setting_info(self._mk3, setting_id)
+            if info is not None:
+                self._setting_info[setting_id] = info
+        return info
+
+    async def _update_settings(self, data: Data) -> None:
+        for setting_id in MONITORED_SETTING_IDS:
             try:
-                info = self._battery_monitor_info.get(setting_id)
-                if info is None:
-                    info = await read_setting_info(self._mk3, setting_id)
-                    if info is not None:
-                        self._battery_monitor_info[setting_id] = info
+                info = await self._get_setting_info(setting_id)
                 if info is None:
                     continue
                 data.setting_info[setting_id] = info
@@ -287,7 +405,7 @@ class Controller(Handler):
                     self._last_battery_capacity = value.value
             except Exception:
                 logger.debug(
-                    "Failed to read battery monitor setting %s",
+                    "Failed to read setting %s",
                     setting_id,
                     exc_info=True,
                 )
@@ -298,6 +416,25 @@ class Controller(Handler):
             if capacity is None or not capacity.supported
             else battery_monitor_enabled_from_capacity(capacity.value)
         )
+
+    async def _update_ram_variables(self, data: Data) -> None:
+        for variable_id in MONITORED_RAM_VARIABLE_IDS:
+            try:
+                info = await self._get_ram_variable_info(variable_id)
+                if info is None:
+                    continue
+                data.ram_variable_info[variable_id] = info
+
+                value = await read_ram_variable(self._mk3, variable_id, info)
+                if value is None:
+                    continue
+                data.ram_variable_values[variable_id] = value
+            except Exception:
+                logger.debug(
+                    "Failed to read RAM variable %s",
+                    variable_id,
+                    exc_info=True,
+                )
 
 
 class Context:

--- a/custom_components/victron_mk3/__init__.py
+++ b/custom_components/victron_mk3/__init__.py
@@ -281,7 +281,7 @@ class Controller(Handler):
             float(target_capacity),
         )
 
-    async def set_battery_monitor_setting(self, setting_id: int, value: float) -> None:
+    async def set_setting(self, setting_id: int, value: float) -> None:
         info = await self._get_setting_info(setting_id)
         result = await write_setting(self._mk3, setting_id, value, info)
         if result is None or not result.supported:
@@ -293,6 +293,9 @@ class Controller(Handler):
             and result.value > 0
         ):
             self._last_battery_capacity = result.value
+
+    async def set_battery_monitor_setting(self, setting_id: int, value: float) -> None:
+        await self.set_setting(setting_id, value)
 
     async def set_power_assist_enabled(self, enabled: bool) -> None:
         await self._set_setting_flag(

--- a/custom_components/victron_mk3/__init__.py
+++ b/custom_components/victron_mk3/__init__.py
@@ -43,6 +43,16 @@ from victron_mk3 import (
 import voluptuous as vol
 
 from .battery_monitor import read_battery_soc, register_battery_soc_variable
+from .battery_monitor_settings import (
+    BATTERY_CAPACITY_SETTING_ID,
+    BATTERY_MONITOR_SETTING_IDS,
+    SettingInfo,
+    SettingValue,
+    battery_monitor_enabled_from_capacity,
+    read_setting,
+    read_setting_info,
+    write_setting,
+)
 from .const import (
     AC_PHASES_POLLED,
     CONF_CURRENT_LIMIT,
@@ -96,11 +106,14 @@ SERVICE_SCHEMA = vol.Schema(
 class Data:
     def __init__(self) -> None:
         self.ac: List[ACResponse | None] = [None] * AC_PHASES_POLLED
+        self.battery_monitor_enabled: bool | None = None
         self.battery_soc: float | None = None
         self.config: ConfigResponse | None = None
         self.dc: DCResponse | None = None
         self.led: LEDResponse | None = None
         self.power: PowerResponse | None = None
+        self.setting_info: dict[int, SettingInfo] = {}
+        self.setting_values: dict[int, SettingValue] = {}
         self.version: VersionResponse | None = None
 
     def front_panel_mode(self) -> Mode | None:
@@ -149,6 +162,8 @@ class Controller(Handler):
         self._mk3 = VictronMK3(port)
         self._fault: Fault | None = None
         self._idle = False
+        self._battery_monitor_info: dict[int, SettingInfo] = {}
+        self._last_battery_capacity: float | None = None
         self._version: VersionResponse | None = None
         self.standby: bool | None = None
         self.ac_entities = [[] for _ in range(0, AC_PHASES_POLLED)]
@@ -207,8 +222,10 @@ class Controller(Handler):
                 else None
             )
         data.power = await self._mk3.send_power_request()
+        await self._update_battery_monitor_settings(data)
         try:
-            data.battery_soc = await read_battery_soc(self._mk3)
+            if data.battery_monitor_enabled:
+                data.battery_soc = await read_battery_soc(self._mk3)
         except Exception:
             logger.debug("Failed to read battery state of charge", exc_info=True)
         data.config = await self._mk3.send_config_request()
@@ -218,6 +235,69 @@ class Controller(Handler):
         self, mode: Mode, current_limit: float | None
     ) -> None:
         await self._mk3.send_state_request(MODE_TO_SWITCH_STATE[mode], current_limit)
+
+    async def set_battery_monitor_enabled(self, enabled: bool) -> None:
+        target_capacity = 0 if not enabled else self._last_battery_capacity
+        if enabled and (target_capacity is None or target_capacity <= 0):
+            raise HomeAssistantError(
+                "Set Battery Capacity to a value greater than 0 before enabling Battery Monitor"
+            )
+
+        await self.set_battery_monitor_setting(
+            BATTERY_CAPACITY_SETTING_ID,
+            float(target_capacity),
+        )
+
+    async def set_battery_monitor_setting(self, setting_id: int, value: float) -> None:
+        info = self._battery_monitor_info.get(setting_id)
+        result = await write_setting(self._mk3, setting_id, value, info)
+        if result is None or not result.supported:
+            raise HomeAssistantError(f"Setting {setting_id} is not available")
+
+        if (
+            setting_id == BATTERY_CAPACITY_SETTING_ID
+            and result.value is not None
+            and result.value > 0
+        ):
+            self._last_battery_capacity = result.value
+
+    async def _update_battery_monitor_settings(self, data: Data) -> None:
+        for setting_id in BATTERY_MONITOR_SETTING_IDS:
+            try:
+                info = self._battery_monitor_info.get(setting_id)
+                if info is None:
+                    info = await read_setting_info(self._mk3, setting_id)
+                    if info is not None:
+                        self._battery_monitor_info[setting_id] = info
+                if info is None:
+                    continue
+                data.setting_info[setting_id] = info
+
+                value = await read_setting(self._mk3, setting_id, info)
+                if value is None:
+                    continue
+                data.setting_values[setting_id] = value
+
+                if (
+                    setting_id == BATTERY_CAPACITY_SETTING_ID
+                    and value.supported
+                    and value.value is not None
+                    and value.value > 0
+                ):
+                    self._last_battery_capacity = value.value
+            except Exception:
+                logger.debug(
+                    "Failed to read battery monitor setting %s",
+                    setting_id,
+                    exc_info=True,
+                )
+
+        capacity = data.setting_values.get(BATTERY_CAPACITY_SETTING_ID)
+        data.battery_monitor_enabled = (
+            None
+            if capacity is None or not capacity.supported
+            else battery_monitor_enabled_from_capacity(capacity.value)
+        )
 
 
 class Context:

--- a/custom_components/victron_mk3/__init__.py
+++ b/custom_components/victron_mk3/__init__.py
@@ -346,7 +346,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await controller.start()
     entry.async_on_unload(controller.stop)
 
-    await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     await _async_setup_services(hass)

--- a/custom_components/victron_mk3/__init__.py
+++ b/custom_components/victron_mk3/__init__.py
@@ -42,6 +42,7 @@ from victron_mk3 import (
 )
 import voluptuous as vol
 
+from .battery_monitor import read_battery_soc, register_battery_soc_variable
 from .const import (
     AC_PHASES_POLLED,
     CONF_CURRENT_LIMIT,
@@ -95,6 +96,7 @@ SERVICE_SCHEMA = vol.Schema(
 class Data:
     def __init__(self) -> None:
         self.ac: List[ACResponse | None] = [None] * AC_PHASES_POLLED
+        self.battery_soc: float | None = None
         self.config: ConfigResponse | None = None
         self.dc: DCResponse | None = None
         self.led: LEDResponse | None = None
@@ -153,6 +155,7 @@ class Controller(Handler):
 
     async def start(self) -> None:
         await self._mk3.start(self)
+        register_battery_soc_variable(self._mk3)
 
     async def stop(self) -> None:
         await self._mk3.stop()
@@ -181,6 +184,8 @@ class Controller(Handler):
         if self._idle:
             raise UpdateFailed("Device is asleep")
 
+        register_battery_soc_variable(self._mk3)
+
         if self.standby is not None:
             flags = InterfaceFlags.PANEL_DETECT
             if self.standby:
@@ -202,6 +207,10 @@ class Controller(Handler):
                 else None
             )
         data.power = await self._mk3.send_power_request()
+        try:
+            data.battery_soc = await read_battery_soc(self._mk3)
+        except Exception:
+            logger.debug("Failed to read battery state of charge", exc_info=True)
         data.config = await self._mk3.send_config_request()
         return data
 

--- a/custom_components/victron_mk3/battery_energy.py
+++ b/custom_components/victron_mk3/battery_energy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class BatteryEnergyDirection(str, Enum):
+    INTO_BATTERY = "into_battery"
+    OUT_OF_BATTERY = "out_of_battery"
+
+
+def battery_energy_power_watts(
+    dc_power_watts: float | None, direction: BatteryEnergyDirection
+) -> float | None:
+    if dc_power_watts is None:
+        return None
+
+    if direction is BatteryEnergyDirection.INTO_BATTERY:
+        return max(dc_power_watts, 0.0)
+
+    return max(-dc_power_watts, 0.0)
+
+
+@dataclass
+class BatteryEnergyAccumulator:
+    direction: BatteryEnergyDirection
+    max_interval_seconds: float | None = None
+    total_kwh: float = 0.0
+    _last_power_watts: float | None = None
+    _last_sample_at: datetime | None = None
+
+    def restore(self, total_kwh: float | None) -> None:
+        if total_kwh is None:
+            return
+
+        self.total_kwh = max(total_kwh, 0.0)
+
+    def advance(self, sampled_at: datetime, dc_power_watts: float | None) -> float:
+        power_watts = battery_energy_power_watts(dc_power_watts, self.direction)
+
+        if (
+            power_watts is not None
+            and self._last_power_watts is not None
+            and self._last_sample_at is not None
+        ):
+            elapsed_seconds = (sampled_at - self._last_sample_at).total_seconds()
+            if elapsed_seconds > 0 and (
+                self.max_interval_seconds is None
+                or elapsed_seconds <= self.max_interval_seconds
+            ):
+                self.total_kwh += self._last_power_watts * elapsed_seconds / 3_600_000
+
+        if power_watts is None:
+            self._last_power_watts = None
+            self._last_sample_at = None
+        else:
+            self._last_power_watts = power_watts
+            self._last_sample_at = sampled_at
+
+        return self.total_kwh

--- a/custom_components/victron_mk3/battery_monitor.py
+++ b/custom_components/victron_mk3/battery_monitor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+BATTERY_SOC_VARIABLE_ID = 13
+
+
+def register_battery_soc_variable(mk3: Any) -> None:
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return
+
+    variable_info = getattr(driver, "_variable_info", None)
+    variable_id_queue = getattr(driver, "_variable_id_queue", None)
+    if variable_info is None or variable_id_queue is None:
+        return
+
+    if (
+        BATTERY_SOC_VARIABLE_ID not in variable_info
+        and BATTERY_SOC_VARIABLE_ID not in variable_id_queue
+    ):
+        variable_id_queue.append(BATTERY_SOC_VARIABLE_ID)
+
+
+async def read_battery_soc(mk3: Any) -> float | None:
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    variable_info = getattr(driver, "_variable_info", None)
+    if variable_info is None or BATTERY_SOC_VARIABLE_ID not in variable_info:
+        return None
+
+    value = await _read_ram_variable(
+        driver,
+        BATTERY_SOC_VARIABLE_ID,
+        variable_info[BATTERY_SOC_VARIABLE_ID],
+    )
+    return _normalize_battery_soc(value, variable_info[BATTERY_SOC_VARIABLE_ID])
+
+
+def _normalize_battery_soc(value: float | None, parser: Any) -> float | None:
+    if value is None:
+        return None
+
+    scale = getattr(parser, "_scale", None)
+    if isinstance(scale, (int, float)) and 0 < scale < 1 and 0 <= value <= 1:
+        return value * 100
+
+    return value
+
+
+async def _read_ram_variable(driver: Any, variable_id: int, parser: Any) -> float | None:
+    completed = asyncio.Event()
+    result: dict[str, float | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            if len(msg) < 5:
+                raise ValueError(f"Unexpected RAM variable response length: {len(msg)}")
+
+            code = msg[2]
+            if code == 0x90:
+                result["value"] = None
+                return
+            if code != 0x85:
+                raise ValueError(f"Unexpected RAM variable response code: {code:#x}")
+
+            result["value"] = parser.parse(msg[3:5])
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    driver._send_w_request([0x30, variable_id], completion)
+    timeout = getattr(type(driver), "REQUEST_TIMEOUT_SECONDS", 0.5)
+    await asyncio.wait_for(completed.wait(), timeout)
+
+    error = result["error"]
+    if error is not None:
+        raise error
+
+    return result["value"]

--- a/custom_components/victron_mk3/battery_monitor_settings.py
+++ b/custom_components/victron_mk3/battery_monitor_settings.py
@@ -5,6 +5,16 @@ from dataclasses import dataclass
 from typing import Any
 
 
+FLAGS0_SETTING_ID = 0
+FLAGS1_SETTING_ID = 1
+DISABLE_WAVE_CHECK_FLAG_BIT = 3
+DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT = 7
+DISABLE_CHARGE_FLAG_BIT = 6
+POWER_ASSIST_ENABLED_FLAG_BIT = 5
+WEAK_AC_INPUT_ENABLED_FLAG_BIT = 14
+# Dynamic current limiter is Flags[28], which maps to bit 12 in Flags1.
+DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT = 12
+
 BATTERY_CAPACITY_SETTING_ID = 64
 BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID = 65
 BATTERY_CHARGE_EFFICIENCY_SETTING_ID = 72
@@ -13,6 +23,10 @@ BATTERY_MONITOR_SETTING_IDS = (
     BATTERY_CAPACITY_SETTING_ID,
     BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID,
     BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
+)
+MONITORED_SETTING_IDS = BATTERY_MONITOR_SETTING_IDS + (
+    FLAGS0_SETTING_ID,
+    FLAGS1_SETTING_ID,
 )
 
 
@@ -96,6 +110,64 @@ def battery_monitor_enabled_from_capacity(capacity: float | None) -> bool | None
     if capacity is None:
         return None
     return capacity > 0
+
+
+def setting_flag_supported(info: SettingInfo | None, flag_bit: int) -> bool:
+    return (
+        info is not None
+        and info.supported
+        and info.maximum_raw is not None
+        and 0 <= flag_bit < 16
+        and info.maximum_raw & (1 << flag_bit) != 0
+    )
+
+
+def setting_flag_enabled(value: SettingValue | None, flag_bit: int) -> bool | None:
+    if (
+        value is None
+        or not value.supported
+        or value.raw_value is None
+        or flag_bit < 0
+        or flag_bit >= 16
+    ):
+        return None
+
+    return value.raw_value & (1 << flag_bit) != 0
+
+
+def setting_raw_with_flag(raw_value: int, flag_bit: int, enabled: bool) -> int:
+    if raw_value < 0 or raw_value > 0xFFFF:
+        raise ValueError(f"Setting raw value {raw_value} is out of range")
+    if flag_bit < 0 or flag_bit >= 16:
+        raise ValueError(f"Flag bit {flag_bit} is out of range")
+
+    mask = 1 << flag_bit
+    if enabled:
+        return raw_value | mask
+    return raw_value & ~mask
+
+
+def ups_function_supported(info: SettingInfo | None) -> bool:
+    return setting_flag_supported(
+        info, DISABLE_WAVE_CHECK_FLAG_BIT
+    ) and setting_flag_supported(info, DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT)
+
+
+def ups_function_enabled(value: SettingValue | None) -> bool | None:
+    disable_wave_check = setting_flag_enabled(value, DISABLE_WAVE_CHECK_FLAG_BIT)
+    inverse_disable_wave_check = setting_flag_enabled(
+        value, DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT
+    )
+    if disable_wave_check is None or inverse_disable_wave_check is None:
+        return None
+    return not disable_wave_check
+
+
+def setting_raw_with_ups_function(raw_value: int, enabled: bool) -> int:
+    value = setting_raw_with_flag(raw_value, DISABLE_WAVE_CHECK_FLAG_BIT, not enabled)
+    return setting_raw_with_flag(
+        value, DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT, enabled
+    )
 
 
 async def read_setting_info(mk3: Any, setting_id: int) -> SettingInfo | None:
@@ -192,6 +264,44 @@ async def write_setting(
         return SettingValue(setting_id=setting_id, supported=False)
 
     raw_value = info.raw_from_value(value)
+    completed = asyncio.Event()
+    result: dict[str, SettingValue | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            result["value"] = _parse_setting_write_frame(setting_id, msg, info, raw_value)
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    driver._send_frame("X", [0x33, setting_id & 0xFF, setting_id >> 8])
+    driver._send_w_request([0x34, raw_value & 0xFF, raw_value >> 8], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+async def write_setting_raw(
+    mk3: Any, setting_id: int, raw_value: int, info: SettingInfo | None = None
+) -> SettingValue | None:
+    if raw_value < 0 or raw_value > 0xFFFF:
+        raise ValueError(f"Setting raw value {raw_value} is out of range")
+
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    if info is None:
+        info = await read_setting_info(mk3, setting_id)
+    if info is None:
+        return None
+    if not info.supported:
+        return SettingValue(setting_id=setting_id, supported=False)
+
     completed = asyncio.Event()
     result: dict[str, SettingValue | Exception | None] = {"value": None, "error": None}
 

--- a/custom_components/victron_mk3/battery_monitor_settings.py
+++ b/custom_components/victron_mk3/battery_monitor_settings.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+
+BATTERY_CAPACITY_SETTING_ID = 64
+BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID = 65
+BATTERY_CHARGE_EFFICIENCY_SETTING_ID = 72
+
+BATTERY_MONITOR_SETTING_IDS = (
+    BATTERY_CAPACITY_SETTING_ID,
+    BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID,
+    BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
+)
+
+
+@dataclass
+class SettingInfo:
+    setting_id: int
+    supported: bool
+    scale: float | None = None
+    offset: int | None = None
+    default_raw: int | None = None
+    minimum_raw: int | None = None
+    maximum_raw: int | None = None
+    access_level: int | None = None
+
+    @property
+    def default(self) -> float | None:
+        return None if self.default_raw is None else self.value_from_raw(self.default_raw)
+
+    @property
+    def minimum(self) -> float | None:
+        return None if self.minimum_raw is None else self.value_from_raw(self.minimum_raw)
+
+    @property
+    def maximum(self) -> float | None:
+        return None if self.maximum_raw is None else self.value_from_raw(self.maximum_raw)
+
+    def value_from_raw(self, raw_value: int) -> float:
+        if self.scale is None or self.offset is None:
+            raise ValueError("Setting metadata is incomplete")
+        return self.scale * (raw_value + self.offset)
+
+    def raw_from_value(self, value: float) -> int:
+        if self.scale is None or self.offset is None:
+            raise ValueError("Setting metadata is incomplete")
+        raw_value = round(value / self.scale - self.offset)
+        if raw_value < 0 or raw_value > 0xFFFF:
+            raise ValueError(f"Setting value {value} is out of range")
+        return raw_value
+
+
+@dataclass
+class SettingValue:
+    setting_id: int
+    supported: bool
+    value: float | None = None
+    raw_value: int | None = None
+
+
+KNOWN_SETTING_INFO: dict[int, SettingInfo] = {
+    BATTERY_CAPACITY_SETTING_ID: SettingInfo(
+        setting_id=BATTERY_CAPACITY_SETTING_ID,
+        supported=True,
+        scale=1,
+        offset=0,
+        default_raw=0,
+        minimum_raw=0,
+        maximum_raw=65330,
+    ),
+    BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID: SettingInfo(
+        setting_id=BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID,
+        supported=True,
+        scale=0.5,
+        offset=0,
+        default_raw=170,
+        minimum_raw=60,
+        maximum_raw=200,
+    ),
+    BATTERY_CHARGE_EFFICIENCY_SETTING_ID: SettingInfo(
+        setting_id=BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
+        supported=True,
+        scale=1 / 256,
+        offset=1,
+        default_raw=255,
+        minimum_raw=0,
+        maximum_raw=255,
+    ),
+}
+
+
+def battery_monitor_enabled_from_capacity(capacity: float | None) -> bool | None:
+    if capacity is None:
+        return None
+    return capacity > 0
+
+
+async def read_setting_info(mk3: Any, setting_id: int) -> SettingInfo | None:
+    if setting_id in KNOWN_SETTING_INFO:
+        return _clone_setting_info(KNOWN_SETTING_INFO[setting_id])
+
+    if hasattr(mk3, "send_setting_info_request"):
+        response = await mk3.send_setting_info_request(setting_id)
+        return _coerce_setting_info(response, setting_id)
+
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    completed = asyncio.Event()
+    result: dict[str, SettingInfo | Exception | None] = {"value": None, "error": None}
+    frames: list[bytes] = []
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            frames.append(bytes(msg))
+            parsed = _parse_setting_info_frames(setting_id, frames)
+            if parsed is None:
+                driver._w_completion = completion
+                return
+            result["value"] = parsed
+        except Exception as err:
+            result["error"] = err
+        finally:
+            if result["value"] is not None or result["error"] is not None:
+                completed.set()
+
+    driver._send_w_request([0x35, setting_id & 0xFF, setting_id >> 8], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+async def read_setting(
+    mk3: Any, setting_id: int, info: SettingInfo | None = None
+) -> SettingValue | None:
+    if hasattr(mk3, "send_setting_request"):
+        response = await mk3.send_setting_request(setting_id)
+        return _coerce_setting_value(response, setting_id)
+
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    if info is None:
+        info = await read_setting_info(mk3, setting_id)
+    if info is not None and not info.supported:
+        return SettingValue(setting_id=setting_id, supported=False)
+
+    completed = asyncio.Event()
+    result: dict[str, SettingValue | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            result["value"] = _parse_setting_value_frame(setting_id, msg, info)
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    driver._send_w_request([0x31, setting_id & 0xFF, setting_id >> 8], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+async def write_setting(
+    mk3: Any, setting_id: int, value: float, info: SettingInfo | None = None
+) -> SettingValue | None:
+    if hasattr(mk3, "send_setting_write_request"):
+        response = await mk3.send_setting_write_request(setting_id, value)
+        return _coerce_setting_value(response, setting_id)
+
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    if info is None:
+        info = await read_setting_info(mk3, setting_id)
+    if info is None:
+        return None
+    if not info.supported:
+        return SettingValue(setting_id=setting_id, supported=False)
+
+    raw_value = info.raw_from_value(value)
+    completed = asyncio.Event()
+    result: dict[str, SettingValue | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            result["value"] = _parse_setting_write_frame(setting_id, msg, info, raw_value)
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    driver._send_frame("X", [0x33, setting_id & 0xFF, setting_id >> 8])
+    driver._send_w_request([0x34, raw_value & 0xFF, raw_value >> 8], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+def _request_timeout(driver: Any) -> float:
+    return getattr(type(driver), "REQUEST_TIMEOUT_SECONDS", 0.5)
+
+
+def _clone_setting_info(info: SettingInfo) -> SettingInfo:
+    return SettingInfo(
+        setting_id=info.setting_id,
+        supported=info.supported,
+        scale=info.scale,
+        offset=info.offset,
+        default_raw=info.default_raw,
+        minimum_raw=info.minimum_raw,
+        maximum_raw=info.maximum_raw,
+        access_level=info.access_level,
+    )
+
+
+def _coerce_setting_info(response: Any, setting_id: int) -> SettingInfo | None:
+    if response is None:
+        return None
+    return SettingInfo(
+        setting_id=setting_id,
+        supported=getattr(response, "supported", False),
+        scale=getattr(response, "scale", None),
+        offset=getattr(response, "offset", None),
+        default_raw=getattr(response, "default_raw", None),
+        minimum_raw=getattr(response, "minimum_raw", None),
+        maximum_raw=getattr(response, "maximum_raw", None),
+        access_level=getattr(response, "access_level", None),
+    )
+
+
+def _coerce_setting_value(response: Any, setting_id: int) -> SettingValue | None:
+    if response is None:
+        return None
+    return SettingValue(
+        setting_id=setting_id,
+        supported=getattr(response, "supported", False),
+        value=getattr(response, "value", None),
+        raw_value=getattr(response, "raw_value", None),
+    )
+
+
+def _parse_setting_info_frames(
+    setting_id: int, frames: list[bytes]
+) -> SettingInfo | None:
+    for frame in frames:
+        if len(frame) >= 5 and frame[2] == 0x89 and frame[3] == 0 and frame[4] == 0:
+            return SettingInfo(setting_id=setting_id, supported=False)
+        if len(frame) >= 3 and frame[2] == 0x86:
+            return SettingInfo(setting_id=setting_id, supported=False)
+
+    for frame in frames:
+        if (
+            len(frame) >= 14
+            and frame[2] == 0x89
+            and frame[5] == 0x8A
+            and frame[8] == 0x8B
+            and frame[11] == 0x8C
+        ):
+            maximum = next(
+                (item for item in frames if len(item) >= 5 and item[2] == 0x8D),
+                None,
+            )
+            if maximum is None:
+                return None
+            return SettingInfo(
+                setting_id=setting_id,
+                supported=True,
+                scale=_setting_scale(frame[3:5]),
+                offset=_signed_16bit(frame[6:8]),
+                default_raw=frame[9] | frame[10] << 8,
+                minimum_raw=frame[12] | frame[13] << 8,
+                maximum_raw=maximum[3] | maximum[4] << 8,
+            )
+    return None
+
+
+def _parse_setting_value_frame(
+    setting_id: int, frame: bytes, info: SettingInfo | None
+) -> SettingValue:
+    if len(frame) < 5:
+        raise ValueError(f"Unexpected setting response length: {len(frame)}")
+    if frame[2] == 0x91:
+        return SettingValue(setting_id=setting_id, supported=False)
+    if frame[2] != 0x86:
+        raise ValueError(f"Unexpected setting response code: {frame[2]:#x}")
+
+    raw_value = frame[3] | frame[4] << 8
+    value = raw_value if info is None else info.value_from_raw(raw_value)
+    return SettingValue(
+        setting_id=setting_id,
+        supported=True,
+        value=value,
+        raw_value=raw_value,
+    )
+
+
+def _parse_setting_write_frame(
+    setting_id: int, frame: bytes, info: SettingInfo, raw_value: int
+) -> SettingValue:
+    if len(frame) < 3:
+        raise ValueError(f"Unexpected write response length: {len(frame)}")
+    if frame[2] in (0x80, 0x9B):
+        return SettingValue(setting_id=setting_id, supported=False)
+    if frame[2] != 0x88:
+        raise ValueError(f"Unexpected write response code: {frame[2]:#x}")
+
+    return SettingValue(
+        setting_id=setting_id,
+        supported=True,
+        value=info.value_from_raw(raw_value),
+        raw_value=raw_value,
+    )
+
+
+def _setting_scale(raw: bytes) -> float:
+    scale = _signed_16bit(raw)
+    if scale == 0:
+        raise ValueError("Unsupported setting scale")
+    return scale if scale > 0 else 1 / (-scale)
+
+
+def _signed_16bit(raw: bytes) -> int:
+    value = raw[0] | raw[1] << 8
+    if value >= 0x8000:
+        value -= 0x10000
+    return value

--- a/custom_components/victron_mk3/battery_monitor_settings.py
+++ b/custom_components/victron_mk3/battery_monitor_settings.py
@@ -18,6 +18,9 @@ DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT = 12
 BATTERY_CAPACITY_SETTING_ID = 64
 BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID = 65
 BATTERY_CHARGE_EFFICIENCY_SETTING_ID = 72
+DC_INPUT_LOW_SHUTDOWN_SETTING_ID = 11
+# VE.Bus stores low restart as an offset above the low shut-down voltage.
+DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID = 12
 
 BATTERY_MONITOR_SETTING_IDS = (
     BATTERY_CAPACITY_SETTING_ID,
@@ -25,6 +28,8 @@ BATTERY_MONITOR_SETTING_IDS = (
     BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
 )
 MONITORED_SETTING_IDS = BATTERY_MONITOR_SETTING_IDS + (
+    DC_INPUT_LOW_SHUTDOWN_SETTING_ID,
+    DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID,
     FLAGS0_SETTING_ID,
     FLAGS1_SETTING_ID,
 )
@@ -168,6 +173,74 @@ def setting_raw_with_ups_function(raw_value: int, enabled: bool) -> int:
     return setting_raw_with_flag(
         value, DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT, enabled
     )
+
+
+def numeric_setting_range(
+    info: SettingInfo | None, value: SettingValue | None
+) -> tuple[float, float, float, float] | None:
+    if (
+        info is None
+        or not info.supported
+        or info.minimum is None
+        or info.maximum is None
+        or info.scale is None
+        or value is None
+        or not value.supported
+        or value.value is None
+    ):
+        return None
+
+    return (
+        info.minimum,
+        info.maximum,
+        abs(info.scale),
+        value.value,
+    )
+
+
+def relative_numeric_setting_range(
+    base_value: float | None,
+    info: SettingInfo | None,
+    value: SettingValue | None,
+) -> tuple[float, float, float, float] | None:
+    absolute_value = relative_setting_absolute_value(base_value, value)
+    if (
+        base_value is None
+        or absolute_value is None
+        or info is None
+        or not info.supported
+        or info.minimum is None
+        or info.maximum is None
+        or info.scale is None
+    ):
+        return None
+
+    return (
+        base_value + info.minimum,
+        base_value + info.maximum,
+        abs(info.scale),
+        absolute_value,
+    )
+
+
+def relative_setting_absolute_value(
+    base_value: float | None, value: SettingValue | None
+) -> float | None:
+    if (
+        base_value is None
+        or value is None
+        or not value.supported
+        or value.value is None
+    ):
+        return None
+
+    return base_value + value.value
+
+
+def relative_setting_offset_from_absolute(
+    base_value: float, absolute_value: float
+) -> float:
+    return absolute_value - base_value
 
 
 async def read_setting_info(mk3: Any, setting_id: int) -> SettingInfo | None:

--- a/custom_components/victron_mk3/number.py
+++ b/custom_components/victron_mk3/number.py
@@ -33,6 +33,8 @@ async def set_remote_panel_current_limit(context: Context, value: float) -> None
         raise HomeAssistantError("Device is not available")
 
     mode = data.remote_panel_mode()
+    if mode is None:
+        raise HomeAssistantError("Device is not available")
     await context.controller.set_remote_panel_state(mode, value)
     await context.coordinator.async_request_refresh()
 

--- a/custom_components/victron_mk3/number.py
+++ b/custom_components/victron_mk3/number.py
@@ -8,7 +8,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfElectricCurrent
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,6 +16,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from typing import Awaitable, Callable
 
 from . import Context, Data
+from .battery_monitor_settings import (
+    BATTERY_CAPACITY_SETTING_ID,
+    BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
+    BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID,
+)
 from .const import (
     DOMAIN,
     KEY_CONTEXT,
@@ -29,6 +34,13 @@ async def set_remote_panel_current_limit(context: Context, value: float) -> None
 
     mode = data.remote_panel_mode()
     await context.controller.set_remote_panel_state(mode, value)
+    await context.coordinator.async_request_refresh()
+
+
+async def set_battery_monitor_setting(
+    context: Context, setting_id: int, value: float
+) -> None:
+    await context.controller.set_battery_monitor_setting(setting_id, value)
     await context.coordinator.async_request_refresh()
 
 
@@ -56,7 +68,70 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3NumberEntityDescription, ...] = (
         ),
         set_fn=set_remote_panel_current_limit,
     ),
+    VictronMK3NumberEntityDescription(
+        key="battery_capacity",
+        name="Battery Capacity",
+        native_unit_of_measurement="Ah",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        range_fn=lambda data: battery_monitor_setting_range(
+            data, BATTERY_CAPACITY_SETTING_ID
+        ),
+        set_fn=lambda context, value: set_battery_monitor_setting(
+            context, BATTERY_CAPACITY_SETTING_ID, value
+        ),
+    ),
+    VictronMK3NumberEntityDescription(
+        key="battery_soc_when_bulk_finished",
+        name="State of Charge When Bulk Finished",
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        range_fn=lambda data: battery_monitor_setting_range(
+            data, BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID
+        ),
+        set_fn=lambda context, value: set_battery_monitor_setting(
+            context, BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID, value
+        ),
+    ),
+    VictronMK3NumberEntityDescription(
+        key="battery_charge_efficiency",
+        name="Charge Efficiency",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        range_fn=lambda data: battery_monitor_setting_range(
+            data, BATTERY_CHARGE_EFFICIENCY_SETTING_ID
+        ),
+        set_fn=lambda context, value: set_battery_monitor_setting(
+            context, BATTERY_CHARGE_EFFICIENCY_SETTING_ID, value
+        ),
+    ),
 )
+
+
+def battery_monitor_setting_range(
+    data: Data, setting_id: int
+) -> tuple[float, float, float, float] | None:
+    info = data.setting_info.get(setting_id)
+    value = data.setting_values.get(setting_id)
+    if (
+        info is None
+        or not info.supported
+        or info.minimum is None
+        or info.maximum is None
+        or info.scale is None
+        or value is None
+        or not value.supported
+        or value.value is None
+    ):
+        return None
+
+    return (
+        info.minimum,
+        info.maximum,
+        abs(info.scale),
+        value.value,
+    )
 
 
 class VictronMK3NumberEntity(CoordinatorEntity, NumberEntity):

--- a/custom_components/victron_mk3/number.py
+++ b/custom_components/victron_mk3/number.py
@@ -8,7 +8,12 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfElectricCurrent
+from homeassistant.const import (
+    EntityCategory,
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,6 +25,11 @@ from .battery_monitor_settings import (
     BATTERY_CAPACITY_SETTING_ID,
     BATTERY_CHARGE_EFFICIENCY_SETTING_ID,
     BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID,
+    DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID,
+    DC_INPUT_LOW_SHUTDOWN_SETTING_ID,
+    numeric_setting_range,
+    relative_numeric_setting_range,
+    relative_setting_offset_from_absolute,
 )
 from .const import (
     DOMAIN,
@@ -42,7 +52,24 @@ async def set_remote_panel_current_limit(context: Context, value: float) -> None
 async def set_battery_monitor_setting(
     context: Context, setting_id: int, value: float
 ) -> None:
-    await context.controller.set_battery_monitor_setting(setting_id, value)
+    await context.controller.set_setting(setting_id, value)
+    await context.coordinator.async_request_refresh()
+
+
+async def set_dc_input_low_restart(context: Context, absolute_value: float) -> None:
+    data = context.coordinator.data
+    shutdown_value = (
+        None
+        if data is None
+        else relative_setting_base_value(data, DC_INPUT_LOW_SHUTDOWN_SETTING_ID)
+    )
+    if shutdown_value is None:
+        raise HomeAssistantError("Device is not available")
+
+    await context.controller.set_setting(
+        DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID,
+        relative_setting_offset_from_absolute(shutdown_value, absolute_value),
+    )
     await context.coordinator.async_request_refresh()
 
 
@@ -76,9 +103,7 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3NumberEntityDescription, ...] = (
         native_unit_of_measurement="Ah",
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
-        range_fn=lambda data: battery_monitor_setting_range(
-            data, BATTERY_CAPACITY_SETTING_ID
-        ),
+        range_fn=lambda data: setting_range(data, BATTERY_CAPACITY_SETTING_ID),
         set_fn=lambda context, value: set_battery_monitor_setting(
             context, BATTERY_CAPACITY_SETTING_ID, value
         ),
@@ -89,7 +114,7 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3NumberEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
-        range_fn=lambda data: battery_monitor_setting_range(
+        range_fn=lambda data: setting_range(
             data, BATTERY_SOC_WHEN_BULK_FINISHED_SETTING_ID
         ),
         set_fn=lambda context, value: set_battery_monitor_setting(
@@ -101,38 +126,59 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3NumberEntityDescription, ...] = (
         name="Charge Efficiency",
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
-        range_fn=lambda data: battery_monitor_setting_range(
+        range_fn=lambda data: setting_range(
             data, BATTERY_CHARGE_EFFICIENCY_SETTING_ID
         ),
         set_fn=lambda context, value: set_battery_monitor_setting(
             context, BATTERY_CHARGE_EFFICIENCY_SETTING_ID, value
         ),
     ),
+    VictronMK3NumberEntityDescription(
+        key="dc_input_low_shutdown",
+        name="DC Input Low Shut-down",
+        device_class=NumberDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        range_fn=lambda data: setting_range(data, DC_INPUT_LOW_SHUTDOWN_SETTING_ID),
+        set_fn=lambda context, value: set_battery_monitor_setting(
+            context, DC_INPUT_LOW_SHUTDOWN_SETTING_ID, value
+        ),
+    ),
+    VictronMK3NumberEntityDescription(
+        key="dc_input_low_restart",
+        name="DC Input Low Restart",
+        device_class=NumberDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        range_fn=lambda data: dc_input_low_restart_range(data),
+        set_fn=set_dc_input_low_restart,
+    ),
 )
 
 
-def battery_monitor_setting_range(
+def setting_range(
     data: Data, setting_id: int
 ) -> tuple[float, float, float, float] | None:
-    info = data.setting_info.get(setting_id)
-    value = data.setting_values.get(setting_id)
-    if (
-        info is None
-        or not info.supported
-        or info.minimum is None
-        or info.maximum is None
-        or info.scale is None
-        or value is None
-        or not value.supported
-        or value.value is None
-    ):
-        return None
+    return numeric_setting_range(
+        data.setting_info.get(setting_id),
+        data.setting_values.get(setting_id),
+    )
 
-    return (
-        info.minimum,
-        info.maximum,
-        abs(info.scale),
-        value.value,
+
+def relative_setting_base_value(data: Data, setting_id: int) -> float | None:
+    value = data.setting_values.get(setting_id)
+    if value is None or not value.supported:
+        return None
+    return value.value
+
+
+def dc_input_low_restart_range(data: Data) -> tuple[float, float, float, float] | None:
+    return relative_numeric_setting_range(
+        relative_setting_base_value(data, DC_INPUT_LOW_SHUTDOWN_SETTING_ID),
+        data.setting_info.get(DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID),
+        data.setting_values.get(DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID),
     )
 
 

--- a/custom_components/victron_mk3/ram_variables.py
+++ b/custom_components/victron_mk3/ram_variables.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+
+IGNORE_AC_INPUT_VARIABLE_ID = 11
+
+MONITORED_RAM_VARIABLE_IDS = (IGNORE_AC_INPUT_VARIABLE_ID,)
+
+
+@dataclass
+class RamVariableInfo:
+    variable_id: int
+    supported: bool
+    signed: bool | None = None
+    scale: float | None = None
+    offset: int | None = None
+    bit: int | None = None
+
+
+@dataclass
+class RamVariableValue:
+    variable_id: int
+    supported: bool
+    value: float | None = None
+    raw_value: int | None = None
+
+
+def ram_variable_bool_supported(info: RamVariableInfo | None) -> bool:
+    return (
+        info is not None
+        and info.supported
+        and (
+            info.bit is not None
+            or (info.scale is not None and info.offset is not None)
+        )
+    )
+
+
+def ram_variable_bool_enabled(
+    value: RamVariableValue | None, info: RamVariableInfo | None
+) -> bool | None:
+    if value is None or not value.supported or value.raw_value is None:
+        return None
+
+    if info is not None and info.bit is not None:
+        return value.raw_value & (1 << info.bit) != 0
+
+    if value.raw_value in (0, 1):
+        return value.raw_value == 1
+    if value.value in (0, 1):
+        return value.value == 1
+    return None
+
+
+async def read_ram_variable_info(mk3: Any, variable_id: int) -> RamVariableInfo | None:
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    completed = asyncio.Event()
+    result: dict[str, RamVariableInfo | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            result["value"] = _parse_ram_variable_info_frame(variable_id, msg)
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    _select_ram_variable_address(driver)
+    driver._send_w_request([0x36, variable_id & 0xFF, variable_id >> 8], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+async def read_ram_variable(
+    mk3: Any, variable_id: int, info: RamVariableInfo | None = None
+) -> RamVariableValue | None:
+    driver = getattr(mk3, "_driver", None)
+    if driver is None:
+        return None
+
+    if info is None:
+        info = await read_ram_variable_info(mk3, variable_id)
+    if info is not None and not info.supported:
+        return RamVariableValue(variable_id=variable_id, supported=False)
+
+    completed = asyncio.Event()
+    result: dict[str, RamVariableValue | Exception | None] = {"value": None, "error": None}
+
+    def completion(_handler: Any, msg: bytes) -> None:
+        try:
+            result["value"] = _parse_ram_variable_value_frame(variable_id, msg, info)
+        except Exception as err:
+            result["error"] = err
+        finally:
+            completed.set()
+
+    _select_ram_variable_address(driver)
+    driver._send_w_request([0x30, variable_id & 0xFF], completion)
+    await asyncio.wait_for(completed.wait(), _request_timeout(driver))
+
+    error = result["error"]
+    if error is not None:
+        raise error
+    return result["value"]
+
+
+def _request_timeout(driver: Any) -> float:
+    return getattr(type(driver), "REQUEST_TIMEOUT_SECONDS", 0.5)
+
+
+def _select_ram_variable_address(driver: Any) -> None:
+    send_frame = getattr(driver, "_send_frame", None)
+    if send_frame is not None:
+        send_frame("A", [1, 0])
+
+
+def _parse_ram_variable_info_frame(
+    variable_id: int, frame: bytes
+) -> RamVariableInfo:
+    if len(frame) < 5:
+        raise ValueError(f"Unexpected RAM variable info response length: {len(frame)}")
+    if frame[2] != 0x8E:
+        raise ValueError(f"Unexpected RAM variable info response code: {frame[2]:#x}")
+
+    sc_raw = frame[3] | frame[4] << 8
+    if sc_raw == 0:
+        return RamVariableInfo(variable_id=variable_id, supported=False)
+
+    if len(frame) < 8 or frame[5] != 0x8F:
+        raise ValueError("Incomplete RAM variable info response")
+
+    offset_raw = frame[6] | frame[7] << 8
+    if offset_raw == 0x8000:
+        return RamVariableInfo(
+            variable_id=variable_id,
+            supported=True,
+            signed=False,
+            offset=-0x8000,
+            bit=abs(_signed_16bit(frame[3:5])) - 1,
+        )
+
+    sc = _signed_16bit(frame[3:5])
+    scale = abs(sc)
+    if scale >= 0x4000:
+        scale = 1 / (0x8000 - scale)
+
+    return RamVariableInfo(
+        variable_id=variable_id,
+        supported=True,
+        signed=sc < 0,
+        scale=scale,
+        offset=_signed_16bit(frame[6:8]),
+    )
+
+
+def _parse_ram_variable_value_frame(
+    variable_id: int, frame: bytes, info: RamVariableInfo | None
+) -> RamVariableValue:
+    if len(frame) < 5:
+        raise ValueError(f"Unexpected RAM variable response length: {len(frame)}")
+
+    code = frame[2]
+    if code == 0x90:
+        return RamVariableValue(variable_id=variable_id, supported=False)
+    if code != 0x85:
+        raise ValueError(f"Unexpected RAM variable response code: {code:#x}")
+
+    raw_value = frame[3] | frame[4] << 8
+    return RamVariableValue(
+        variable_id=variable_id,
+        supported=True,
+        value=_ram_variable_value_from_raw(raw_value, info),
+        raw_value=raw_value,
+    )
+
+
+def _ram_variable_value_from_raw(
+    raw_value: int, info: RamVariableInfo | None
+) -> float | None:
+    if info is None:
+        return raw_value
+    if info.bit is not None:
+        return 1 if raw_value & (1 << info.bit) != 0 else 0
+    if info.scale is None or info.offset is None:
+        return None
+
+    value = raw_value
+    if info.signed and value >= 0x8000:
+        value -= 0x10000
+    return info.scale * (value + info.offset)
+
+
+def _signed_16bit(raw: bytes) -> int:
+    value = raw[0] | raw[1] << 8
+    if value >= 0x8000:
+        value -= 0x10000
+    return value

--- a/custom_components/victron_mk3/remote_panel.py
+++ b/custom_components/victron_mk3/remote_panel.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Mode(Enum):
+    OFF = 0
+    ON = 1
+    CHARGER_ONLY = 2
+    INVERTER_ONLY = 3
+    PASS_THROUGH = 4
+
+
+def enum_options(enum_class: type[Enum]) -> list[str]:
+    return [x.lower() for x in enum_class._member_names_]
+
+
+def enum_value(value: Enum | None) -> str | None:
+    return None if value is None else str(value) if value.name is None else value.name.lower()
+
+
+def mode_from_value(value: str) -> Mode:
+    return Mode[value.upper()]
+
+
+def charger_enabled_in_mode(mode: Mode) -> bool:
+    return mode in (Mode.ON, Mode.CHARGER_ONLY)
+
+
+def inverter_enabled_in_mode(mode: Mode) -> bool:
+    return mode in (Mode.ON, Mode.INVERTER_ONLY, Mode.PASS_THROUGH)
+
+
+def mode_from_enabled_states(charger_enabled: bool, inverter_enabled: bool) -> Mode:
+    if charger_enabled and inverter_enabled:
+        return Mode.ON
+    if charger_enabled:
+        return Mode.CHARGER_ONLY
+    if inverter_enabled:
+        return Mode.PASS_THROUGH
+    return Mode.OFF
+
+
+def mode_with_charger_enabled(mode: Mode, enabled: bool) -> Mode:
+    return mode_from_enabled_states(
+        charger_enabled=enabled,
+        inverter_enabled=inverter_enabled_in_mode(mode),
+    )
+
+
+def mode_with_disable_charge(base_mode: Mode, disable_charge: bool) -> Mode:
+    if disable_charge and base_mode is Mode.ON:
+        return Mode.PASS_THROUGH
+    return base_mode
+
+
+def base_mode_for_remote_panel(mode: Mode) -> Mode:
+    if mode is Mode.PASS_THROUGH:
+        return Mode.ON
+    return mode
+
+
+def disable_charge_for_remote_panel(mode: Mode) -> bool:
+    return mode is Mode.PASS_THROUGH

--- a/custom_components/victron_mk3/select.py
+++ b/custom_components/victron_mk3/select.py
@@ -13,11 +13,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from typing import Awaitable, Callable
 
-from . import Context, Data, Mode, enum_options, enum_value, mode_from_value
+from . import Context, Data
 from .const import (
     DOMAIN,
     KEY_CONTEXT,
 )
+from .remote_panel import Mode, enum_options, enum_value, mode_from_value
 
 
 async def select_remote_panel_mode(context: Context, option: str) -> None:

--- a/custom_components/victron_mk3/sensor.py
+++ b/custom_components/victron_mk3/sensor.py
@@ -26,12 +26,18 @@ from homeassistant.util import dt as dt_util
 from typing import Callable
 from victron_mk3 import DeviceState
 
-from . import Context, Data, Mode, UPDATE_INTERVAL, enum_options, enum_value
+from . import Context, Data, UPDATE_INTERVAL
 from .battery_energy import BatteryEnergyAccumulator, BatteryEnergyDirection
 from .const import (
     AC_PHASES_POLLED,
     DOMAIN,
     KEY_CONTEXT,
+)
+from .remote_panel import Mode, enum_options, enum_value
+from .ram_variables import (
+    IGNORE_AC_INPUT_VARIABLE_ID,
+    ram_variable_bool_enabled,
+    ram_variable_bool_supported,
 )
 
 
@@ -265,9 +271,17 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3SensorEntityDescription, ...] = (
         key="front_panel_mode",
         name="Front Panel Mode",
         device_class=SensorDeviceClass.ENUM,
-        options=enum_options(Mode),
+        options=("off", "on", "charger_only"),
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: enum_value(data.front_panel_mode()),
+    ),
+    VictronMK3SensorEntityDescription(
+        key="ignore_ac_input_state",
+        name="Ignore AC Input State",
+        device_class=SensorDeviceClass.ENUM,
+        options=("off", "on"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: _ignore_ac_input_state(data),
     ),
     VictronMK3SensorEntityDescription(
         key="actual_mode",
@@ -381,6 +395,18 @@ def _parse_float(value: str) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _ignore_ac_input_state(data: Data) -> str | None:
+    info = data.ram_variable_info.get(IGNORE_AC_INPUT_VARIABLE_ID)
+    value = data.ram_variable_values.get(IGNORE_AC_INPUT_VARIABLE_ID)
+    if not ram_variable_bool_supported(info):
+        return None
+
+    enabled = ram_variable_bool_enabled(value, info)
+    if enabled is None:
+        return None
+    return "on" if enabled else "off"
 
 
 async def async_setup_entry(

--- a/custom_components/victron_mk3/sensor.py
+++ b/custom_components/victron_mk3/sensor.py
@@ -206,6 +206,15 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3SensorEntityDescription, ...] = (
         value_fn=lambda data: None if data.power is None else data.power.dc_power,
     ),
     VictronMK3SensorEntityDescription(
+        key="battery_charge_discharge_power",
+        name="Battery Charge Discharge Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=1,
+        value_fn=lambda data: None if data.power is None else -data.power.dc_power,
+    ),
+    VictronMK3SensorEntityDescription(
         key="battery_state_of_charge",
         name="Battery State of Charge",
         device_class=SensorDeviceClass.BATTERY,

--- a/custom_components/victron_mk3/sensor.py
+++ b/custom_components/victron_mk3/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
+    PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfFrequency,
     UnitOfElectricPotential,
@@ -188,6 +189,15 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3SensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=1,
         value_fn=lambda data: None if data.power is None else data.power.dc_power,
+    ),
+    VictronMK3SensorEntityDescription(
+        key="battery_state_of_charge",
+        name="Battery State of Charge",
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=1,
+        value_fn=lambda data: data.battery_soc,
     ),
     VictronMK3SensorEntityDescription(
         key="battery_charger_current",

--- a/custom_components/victron_mk3/sensor.py
+++ b/custom_components/victron_mk3/sensor.py
@@ -12,18 +12,22 @@ from homeassistant.const import (
     EntityCategory,
     PERCENTAGE,
     UnitOfElectricCurrent,
+    UnitOfEnergy,
     UnitOfFrequency,
     UnitOfElectricPotential,
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 from typing import Callable
 from victron_mk3 import DeviceState
 
-from . import Context, Data, Mode, enum_options, enum_value
+from . import Context, Data, Mode, UPDATE_INTERVAL, enum_options, enum_value
+from .battery_energy import BatteryEnergyAccumulator, BatteryEnergyDirection
 from .const import (
     AC_PHASES_POLLED,
     DOMAIN,
@@ -34,6 +38,11 @@ from .const import (
 @dataclass(kw_only=True)
 class VictronMK3SensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[Data], StateType]
+
+
+@dataclass(kw_only=True)
+class VictronMK3BatteryEnergySensorEntityDescription(SensorEntityDescription):
+    direction: BatteryEnergyDirection
 
 
 def make_ac_phase_sensors(phase: int) -> tuple[VictronMK3SensorEntityDescription, ...]:
@@ -271,6 +280,30 @@ ENTITY_DESCRIPTIONS: tuple[VictronMK3SensorEntityDescription, ...] = (
 )
 
 
+BATTERY_ENERGY_ENTITY_DESCRIPTIONS: tuple[
+    VictronMK3BatteryEnergySensorEntityDescription, ...
+] = (
+    VictronMK3BatteryEnergySensorEntityDescription(
+        key="battery_energy_into",
+        name="Battery Energy Into",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=3,
+        direction=BatteryEnergyDirection.INTO_BATTERY,
+    ),
+    VictronMK3BatteryEnergySensorEntityDescription(
+        key="battery_energy_out_of",
+        name="Battery Energy Out Of",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=3,
+        direction=BatteryEnergyDirection.OUT_OF_BATTERY,
+    ),
+)
+
+
 class VictronMK3SensorEntity(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
 
@@ -296,6 +329,60 @@ class VictronMK3SensorEntity(CoordinatorEntity, SensorEntity):
         self.async_write_ha_state()
 
 
+class VictronMK3BatteryEnergySensorEntity(RestoreEntity, CoordinatorEntity, SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        context: Context,
+        entity_description: VictronMK3BatteryEnergySensorEntityDescription,
+    ):
+        CoordinatorEntity.__init__(self, context.coordinator, entity_description.key)
+        self.entity_description = entity_description
+        self._attr_device_info = context.device_info
+        self._attr_unique_id = f"{context.device_id}-{entity_description.key}"
+        self._attr_available = False
+        self._attr_native_value = None
+        self._accumulator = BatteryEnergyAccumulator(
+            direction=entity_description.direction,
+            max_interval_seconds=UPDATE_INTERVAL.total_seconds() * 3,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            restored_value = _parse_float(last_state.state)
+            if restored_value is not None:
+                self._accumulator.restore(restored_value)
+                self._attr_native_value = round(self._accumulator.total_kwh, 6)
+                self._attr_available = True
+
+        if self.coordinator.data is not None:
+            self._handle_coordinator_update()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        data = self.coordinator.data
+        power_watts = None if data is None or data.power is None else data.power.dc_power
+
+        total_kwh = self._accumulator.advance(dt_util.utcnow(), power_watts)
+        if power_watts is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+            self._attr_native_value = round(total_kwh, 6)
+        self.async_write_ha_state()
+
+
+def _parse_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -305,6 +392,10 @@ async def async_setup_entry(
     entities = [
         VictronMK3SensorEntity(context, description)
         for description in ENTITY_DESCRIPTIONS
+    ]
+    entities += [
+        VictronMK3BatteryEnergySensorEntity(context, description)
+        for description in BATTERY_ENERGY_ENTITY_DESCRIPTIONS
     ]
     for phase in range(1, AC_PHASES_POLLED + 1):
         ac_sensors = [

--- a/custom_components/victron_mk3/services.yaml
+++ b/custom_components/victron_mk3/services.yaml
@@ -17,6 +17,7 @@ set_remote_panel_state:
           options:
             - "off"
             - "on"
+            - pass_through
             - charger_only
             - inverter_only
     current_limit:

--- a/custom_components/victron_mk3/switch.py
+++ b/custom_components/victron_mk3/switch.py
@@ -8,8 +8,9 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import Context
@@ -55,10 +56,60 @@ class VictronMK3StandbySwitchEntity(RestoreEntity, SwitchEntity):
         await self.context.coordinator.async_request_refresh()
 
 
+class VictronMK3BatteryMonitorSwitchEntity(CoordinatorEntity, SwitchEntity):
+    _attr_has_entity_name = True
+
+    entity_description = SwitchEntityDescription(
+        key="battery_monitor",
+        name="Battery Monitor",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, context: Context):
+        CoordinatorEntity.__init__(
+            self,
+            context.coordinator,
+            VictronMK3BatteryMonitorSwitchEntity.entity_description.key,
+        )
+        self.context = context
+        self._attr_device_info = context.device_info
+        self._attr_unique_id = (
+            f"{context.device_id}-"
+            f"{VictronMK3BatteryMonitorSwitchEntity.entity_description.key}"
+        )
+        self._attr_available = False
+        self._attr_is_on = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        data = self.coordinator.data
+        value = None if data is None else data.battery_monitor_enabled
+        if value is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+            self._attr_is_on = value
+        self.async_write_ha_state()
+
+    async def async_turn_on(self) -> None:
+        await self.context.controller.set_battery_monitor_enabled(True)
+        await self.context.coordinator.async_request_refresh()
+
+    async def async_turn_off(self) -> None:
+        await self.context.controller.set_battery_monitor_enabled(False)
+        await self.context.coordinator.async_request_refresh()
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     context = hass.data[DOMAIN][entry.entry_id][KEY_CONTEXT]
-    async_add_entities([VictronMK3StandbySwitchEntity(context)])
+    async_add_entities(
+        [
+            VictronMK3StandbySwitchEntity(context),
+            VictronMK3BatteryMonitorSwitchEntity(context),
+        ]
+    )

--- a/custom_components/victron_mk3/switch.py
+++ b/custom_components/victron_mk3/switch.py
@@ -9,15 +9,31 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, STATE_ON
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from typing import Awaitable, Callable
 
 from . import Context
+from .battery_monitor_settings import (
+    DISABLE_WAVE_CHECK_FLAG_BIT,
+    DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT,
+    DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT,
+    FLAGS0_SETTING_ID,
+    FLAGS1_SETTING_ID,
+    POWER_ASSIST_ENABLED_FLAG_BIT,
+    setting_flag_enabled,
+    setting_flag_supported,
+    ups_function_enabled,
+    ups_function_supported,
+    WEAK_AC_INPUT_ENABLED_FLAG_BIT,
+)
 from .const import (
     DOMAIN,
     KEY_CONTEXT,
 )
+from .remote_panel import charger_enabled_in_mode, mode_with_charger_enabled
 
 
 class VictronMK3StandbySwitchEntity(RestoreEntity, SwitchEntity):
@@ -101,6 +117,219 @@ class VictronMK3BatteryMonitorSwitchEntity(CoordinatorEntity, SwitchEntity):
         await self.context.coordinator.async_request_refresh()
 
 
+async def set_charge_enabled(context: Context, enabled: bool) -> None:
+    data = context.coordinator.data
+    if data is None or data.config is None:
+        raise HomeAssistantError("Device is not available")
+
+    mode = data.remote_panel_mode()
+    if mode is None:
+        raise HomeAssistantError("Device is not available")
+
+    await context.controller.set_remote_panel_state(
+        mode_with_charger_enabled(mode, enabled),
+        data.config.actual_current_limit,
+    )
+    await context.coordinator.async_request_refresh()
+
+
+async def set_power_assist_enabled(context: Context, enabled: bool) -> None:
+    await context.controller.set_power_assist_enabled(enabled)
+    await context.coordinator.async_request_refresh()
+
+
+async def set_ups_function_enabled(context: Context, enabled: bool) -> None:
+    await context.controller.set_ups_function_enabled(enabled)
+    await context.coordinator.async_request_refresh()
+
+
+async def set_dynamic_current_limiter_enabled(context: Context, enabled: bool) -> None:
+    await context.controller.set_dynamic_current_limiter_enabled(enabled)
+    await context.coordinator.async_request_refresh()
+
+
+async def set_weak_ac_input_enabled(context: Context, enabled: bool) -> None:
+    await context.controller.set_weak_ac_input_enabled(enabled)
+    await context.coordinator.async_request_refresh()
+
+
+@dataclass(kw_only=True)
+class VictronMK3SettingFlagSwitchEntityDescription(SwitchEntityDescription):
+    setting_id: int
+    flag_bit: int
+    set_fn: Callable[[Context, bool], Awaitable[None]]
+
+
+class VictronMK3ChargeEnabledSwitchEntity(CoordinatorEntity, SwitchEntity):
+    _attr_has_entity_name = True
+
+    entity_description = SwitchEntityDescription(
+        key="charge_enabled",
+        name="Charge Enabled",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, context: Context):
+        CoordinatorEntity.__init__(
+            self,
+            context.coordinator,
+            VictronMK3ChargeEnabledSwitchEntity.entity_description.key,
+        )
+        self.context = context
+        self._attr_device_info = context.device_info
+        self._attr_unique_id = (
+            f"{context.device_id}-"
+            f"{VictronMK3ChargeEnabledSwitchEntity.entity_description.key}"
+        )
+        self._attr_available = False
+        self._attr_is_on = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        data = self.coordinator.data
+        mode = None if data is None else data.remote_panel_mode()
+        if mode is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+            self._attr_is_on = charger_enabled_in_mode(mode)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self) -> None:
+        await set_charge_enabled(self.context, True)
+
+    async def async_turn_off(self) -> None:
+        await set_charge_enabled(self.context, False)
+
+
+class VictronMK3UpsFunctionSwitchEntity(CoordinatorEntity, SwitchEntity):
+    _attr_has_entity_name = True
+
+    entity_description = SwitchEntityDescription(
+        key="ups_function",
+        name="UPS Function",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, context: Context):
+        CoordinatorEntity.__init__(
+            self,
+            context.coordinator,
+            VictronMK3UpsFunctionSwitchEntity.entity_description.key,
+        )
+        self.context = context
+        self._attr_device_info = context.device_info
+        self._attr_unique_id = (
+            f"{context.device_id}-"
+            f"{VictronMK3UpsFunctionSwitchEntity.entity_description.key}"
+        )
+        self._attr_available = False
+        self._attr_is_on = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        data = self.coordinator.data
+        info = None if data is None else data.setting_info.get(FLAGS0_SETTING_ID)
+        value = None if data is None else data.setting_values.get(FLAGS0_SETTING_ID)
+        is_on = ups_function_enabled(value)
+        if not ups_function_supported(info) or is_on is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+            self._attr_is_on = is_on
+        self.async_write_ha_state()
+
+    async def async_turn_on(self) -> None:
+        await set_ups_function_enabled(self.context, True)
+
+    async def async_turn_off(self) -> None:
+        await set_ups_function_enabled(self.context, False)
+
+
+SETTING_FLAG_ENTITY_DESCRIPTIONS: tuple[VictronMK3SettingFlagSwitchEntityDescription, ...] = (
+    VictronMK3SettingFlagSwitchEntityDescription(
+        key="power_assist",
+        name="PowerAssist",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        setting_id=FLAGS0_SETTING_ID,
+        flag_bit=POWER_ASSIST_ENABLED_FLAG_BIT,
+        set_fn=set_power_assist_enabled,
+    ),
+    VictronMK3SettingFlagSwitchEntityDescription(
+        key="dynamic_current_limiter",
+        name="Dynamic Current Limiter",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        setting_id=FLAGS1_SETTING_ID,
+        flag_bit=DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT,
+        set_fn=set_dynamic_current_limiter_enabled,
+    ),
+    VictronMK3SettingFlagSwitchEntityDescription(
+        key="weak_ac_input",
+        name="Weak AC Input",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        setting_id=FLAGS0_SETTING_ID,
+        flag_bit=WEAK_AC_INPUT_ENABLED_FLAG_BIT,
+        set_fn=set_weak_ac_input_enabled,
+    ),
+)
+
+
+class VictronMK3SettingFlagSwitchEntity(CoordinatorEntity, SwitchEntity):
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        context: Context,
+        entity_description: VictronMK3SettingFlagSwitchEntityDescription,
+    ):
+        CoordinatorEntity.__init__(
+            self,
+            context.coordinator,
+            entity_description.key,
+        )
+        self.context = context
+        self.entity_description = entity_description
+        self._attr_device_info = context.device_info
+        self._attr_unique_id = f"{context.device_id}-{entity_description.key}"
+        self._attr_available = False
+        self._attr_is_on = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        data = self.coordinator.data
+        info = (
+            None
+            if data is None
+            else data.setting_info.get(self.entity_description.setting_id)
+        )
+        value = (
+            None
+            if data is None
+            else data.setting_values.get(self.entity_description.setting_id)
+        )
+        is_on = setting_flag_enabled(value, self.entity_description.flag_bit)
+        if (
+            not setting_flag_supported(info, self.entity_description.flag_bit)
+            or is_on is None
+        ):
+            self._attr_available = False
+        else:
+            self._attr_available = True
+            self._attr_is_on = is_on
+        self.async_write_ha_state()
+
+    async def async_turn_on(self) -> None:
+        await self.entity_description.set_fn(self.context, True)
+
+    async def async_turn_off(self) -> None:
+        await self.entity_description.set_fn(self.context, False)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -111,5 +340,11 @@ async def async_setup_entry(
         [
             VictronMK3StandbySwitchEntity(context),
             VictronMK3BatteryMonitorSwitchEntity(context),
+            VictronMK3ChargeEnabledSwitchEntity(context),
+            VictronMK3UpsFunctionSwitchEntity(context),
+            *(
+                VictronMK3SettingFlagSwitchEntity(context, description)
+                for description in SETTING_FLAG_ENTITY_DESCRIPTIONS
+            ),
         ]
     )

--- a/tests/test_battery_energy.py
+++ b/tests/test_battery_energy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "victron_mk3"
+    / "battery_energy.py"
+)
+SPEC = importlib.util.spec_from_file_location("battery_energy", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+battery_energy = importlib.util.module_from_spec(SPEC)
+sys.modules["battery_energy"] = battery_energy
+SPEC.loader.exec_module(battery_energy)
+
+
+def test_into_battery_accumulator_integrates_positive_power_only() -> None:
+    accumulator = battery_energy.BatteryEnergyAccumulator(
+        direction=battery_energy.BatteryEnergyDirection.INTO_BATTERY
+    )
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    assert accumulator.advance(start, 1200.0) == 0.0
+    total = accumulator.advance(start + timedelta(minutes=30), 0.0)
+
+    assert round(total, 6) == 0.6
+
+
+def test_out_of_battery_accumulator_integrates_negative_power_only() -> None:
+    accumulator = battery_energy.BatteryEnergyAccumulator(
+        direction=battery_energy.BatteryEnergyDirection.OUT_OF_BATTERY
+    )
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    assert accumulator.advance(start, -600.0) == 0.0
+    total = accumulator.advance(start + timedelta(minutes=15), 0.0)
+
+    assert round(total, 6) == 0.15
+
+
+def test_accumulator_skips_gaps_larger_than_max_interval() -> None:
+    accumulator = battery_energy.BatteryEnergyAccumulator(
+        direction=battery_energy.BatteryEnergyDirection.INTO_BATTERY,
+        max_interval_seconds=30,
+    )
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    accumulator.advance(start, 1000.0)
+    total = accumulator.advance(start + timedelta(minutes=2), 1000.0)
+
+    assert total == 0.0
+
+
+def test_accumulator_restore_preserves_existing_total() -> None:
+    accumulator = battery_energy.BatteryEnergyAccumulator(
+        direction=battery_energy.BatteryEnergyDirection.OUT_OF_BATTERY
+    )
+    accumulator.restore(1.25)
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    assert accumulator.advance(start, -500.0) == 1.25
+    total = accumulator.advance(start + timedelta(hours=1), 0.0)
+
+    assert round(total, 6) == 1.75
+
+
+def test_battery_energy_power_watts_splits_charge_and_discharge() -> None:
+    assert (
+        battery_energy.battery_energy_power_watts(
+            450.0, battery_energy.BatteryEnergyDirection.INTO_BATTERY
+        )
+        == 450.0
+    )
+    assert (
+        battery_energy.battery_energy_power_watts(
+            450.0, battery_energy.BatteryEnergyDirection.OUT_OF_BATTERY
+        )
+        == 0.0
+    )
+    assert (
+        battery_energy.battery_energy_power_watts(
+            -450.0, battery_energy.BatteryEnergyDirection.OUT_OF_BATTERY
+        )
+        == 450.0
+    )

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "victron_mk3"
+    / "battery_monitor.py"
+)
+SPEC = importlib.util.spec_from_file_location("battery_monitor", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+battery_monitor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(battery_monitor)
+
+
+class FakeParser:
+    def __init__(self, value: float, scale: float = 1) -> None:
+        self.value = value
+        self._scale = scale
+        self.raw: bytes | None = None
+
+    def parse(self, raw: bytes) -> float:
+        self.raw = raw
+        return self.value
+
+
+class FakeDriver:
+    REQUEST_TIMEOUT_SECONDS = 0.1
+
+    def __init__(self, response: bytes | None = None) -> None:
+        self._variable_info = {}
+        self._variable_id_queue = []
+        self.response = response
+        self.request: list[int] | None = None
+
+    def _send_w_request(self, msg: list[int], completion) -> None:
+        self.request = msg
+        if self.response is not None:
+            completion(None, self.response)
+
+
+class FakeMK3:
+    def __init__(self, driver: FakeDriver | None) -> None:
+        self._driver = driver
+
+
+def test_register_battery_soc_variable_appends_once() -> None:
+    driver = FakeDriver()
+    mk3 = FakeMK3(driver)
+
+    battery_monitor.register_battery_soc_variable(mk3)
+    battery_monitor.register_battery_soc_variable(mk3)
+
+    assert driver._variable_id_queue == [battery_monitor.BATTERY_SOC_VARIABLE_ID]
+
+
+def test_register_battery_soc_variable_skips_known_variables() -> None:
+    driver = FakeDriver()
+    driver._variable_info[battery_monitor.BATTERY_SOC_VARIABLE_ID] = object()
+
+    battery_monitor.register_battery_soc_variable(FakeMK3(driver))
+
+    assert driver._variable_id_queue == []
+
+
+def test_read_battery_soc_returns_none_until_variable_info_is_available() -> None:
+    value = asyncio.run(battery_monitor.read_battery_soc(FakeMK3(FakeDriver())))
+
+    assert value is None
+
+
+def test_read_battery_soc_reads_ram_variable_13() -> None:
+    parser = FakeParser(78.5)
+    driver = FakeDriver(bytes([0x00, 0x00, 0x85, 0x34, 0x12]))
+    driver._variable_info[battery_monitor.BATTERY_SOC_VARIABLE_ID] = parser
+
+    value = asyncio.run(battery_monitor.read_battery_soc(FakeMK3(driver)))
+
+    assert driver.request == [0x30, battery_monitor.BATTERY_SOC_VARIABLE_ID]
+    assert parser.raw == bytes([0x34, 0x12])
+    assert value == 78.5
+
+
+def test_read_battery_soc_converts_fractional_values_to_percentage() -> None:
+    parser = FakeParser(0.99, scale=0.01)
+    driver = FakeDriver(bytes([0x00, 0x00, 0x85, 0x63, 0x00]))
+    driver._variable_info[battery_monitor.BATTERY_SOC_VARIABLE_ID] = parser
+
+    value = asyncio.run(battery_monitor.read_battery_soc(FakeMK3(driver)))
+
+    assert value == 99.0
+
+
+def test_read_battery_soc_returns_none_for_unsupported_variable() -> None:
+    parser = FakeParser(0)
+    driver = FakeDriver(bytes([0x00, 0x00, 0x90, 0x00, 0x00]))
+    driver._variable_info[battery_monitor.BATTERY_SOC_VARIABLE_ID] = parser
+
+    value = asyncio.run(battery_monitor.read_battery_soc(FakeMK3(driver)))
+
+    assert value is None
+    assert parser.raw is None

--- a/tests/test_battery_monitor_settings.py
+++ b/tests/test_battery_monitor_settings.py
@@ -155,6 +155,95 @@ def test_write_setting_sends_write_setting_then_write_data() -> None:
     assert value.value == 90
 
 
+def test_write_setting_raw_sends_raw_setting_value() -> None:
+    driver = FakeDriver([bytes.fromhex("ff59880000")])
+    info = battery_monitor_settings.SettingInfo(
+        setting_id=0,
+        supported=True,
+        scale=1,
+        offset=0,
+        default_raw=0,
+        minimum_raw=0,
+        maximum_raw=0xFFFF,
+    )
+
+    value = asyncio.run(
+        battery_monitor_settings.write_setting_raw(FakeMK3(driver), 0, 0x24, info)
+    )
+
+    assert driver.frames == [("X", [0x33, 0, 0])]
+    assert driver.requests == [[0x34, 0x24, 0]]
+    assert value is not None
+    assert value.supported
+    assert value.raw_value == 0x24
+    assert value.value == 0x24
+
+
+def test_setting_flag_helpers_use_raw_bit_masks() -> None:
+    info = battery_monitor_settings.SettingInfo(
+        setting_id=0,
+        supported=True,
+        scale=1,
+        offset=0,
+        maximum_raw=(
+            (1 << battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT)
+            | (1 << battery_monitor_settings.DISABLE_WAVE_CHECK_FLAG_BIT)
+            | (1 << battery_monitor_settings.DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT)
+        ),
+    )
+    value = battery_monitor_settings.SettingValue(
+        setting_id=0,
+        supported=True,
+        raw_value=(
+            (1 << battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT)
+            | (1 << battery_monitor_settings.DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT)
+        ),
+    )
+
+    assert battery_monitor_settings.setting_flag_supported(
+        info,
+        battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT,
+    )
+    assert not battery_monitor_settings.setting_flag_supported(info, 4)
+    assert battery_monitor_settings.setting_flag_enabled(
+        value,
+        battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT,
+    )
+    assert (
+        battery_monitor_settings.setting_raw_with_flag(
+            0,
+            battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT,
+            True,
+        )
+        == 1 << battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT
+    )
+    assert (
+        battery_monitor_settings.setting_raw_with_flag(
+            0xFFFF,
+            battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT,
+            False,
+        )
+        == 0xFFFF & ~(1 << battery_monitor_settings.POWER_ASSIST_ENABLED_FLAG_BIT)
+    )
+    assert battery_monitor_settings.ups_function_supported(info)
+    assert battery_monitor_settings.ups_function_enabled(value)
+    assert (
+        battery_monitor_settings.setting_raw_with_ups_function(0, True)
+        == 1 << battery_monitor_settings.DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT
+    )
+    assert (
+        battery_monitor_settings.setting_raw_with_ups_function(0xFFFF, False)
+        == 0xFFFF
+        & ~(1 << battery_monitor_settings.DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT)
+    )
+    assert battery_monitor_settings.DISABLE_WAVE_CHECK_FLAG_BIT == 3
+    assert battery_monitor_settings.DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT == 7
+    assert battery_monitor_settings.FLAGS1_SETTING_ID == 1
+    assert battery_monitor_settings.DISABLE_CHARGE_FLAG_BIT == 6
+    assert battery_monitor_settings.WEAK_AC_INPUT_ENABLED_FLAG_BIT == 14
+    assert battery_monitor_settings.DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT == 12
+
+
 def test_public_setting_api_is_coerced() -> None:
     info = asyncio.run(battery_monitor_settings.read_setting_info(PublicMK3(), 64))
     value = asyncio.run(battery_monitor_settings.read_setting(PublicMK3(), 72))

--- a/tests/test_battery_monitor_settings.py
+++ b/tests/test_battery_monitor_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import math
 from pathlib import Path
 import sys
 
@@ -242,6 +243,59 @@ def test_setting_flag_helpers_use_raw_bit_masks() -> None:
     assert battery_monitor_settings.DISABLE_CHARGE_FLAG_BIT == 6
     assert battery_monitor_settings.WEAK_AC_INPUT_ENABLED_FLAG_BIT == 14
     assert battery_monitor_settings.DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT == 12
+
+
+def test_numeric_setting_range_helpers_cover_absolute_and_relative_values() -> None:
+    info = battery_monitor_settings.SettingInfo(
+        setting_id=battery_monitor_settings.DC_INPUT_LOW_SHUTDOWN_SETTING_ID,
+        supported=True,
+        scale=0.01,
+        offset=0,
+        minimum_raw=930,
+        maximum_raw=1300,
+    )
+    value = battery_monitor_settings.SettingValue(
+        setting_id=battery_monitor_settings.DC_INPUT_LOW_SHUTDOWN_SETTING_ID,
+        supported=True,
+        raw_value=1150,
+        value=11.5,
+    )
+    relative_info = battery_monitor_settings.SettingInfo(
+        setting_id=battery_monitor_settings.DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID,
+        supported=True,
+        scale=0.01,
+        offset=0,
+        minimum_raw=25,
+        maximum_raw=600,
+    )
+    relative_value = battery_monitor_settings.SettingValue(
+        setting_id=battery_monitor_settings.DC_INPUT_LOW_RESTART_OFFSET_SETTING_ID,
+        supported=True,
+        raw_value=160,
+        value=1.6,
+    )
+
+    assert battery_monitor_settings.numeric_setting_range(info, value) == (
+        9.3,
+        13.0,
+        0.01,
+        11.5,
+    )
+    assert battery_monitor_settings.relative_setting_absolute_value(11.5, relative_value) == 13.1
+    assert battery_monitor_settings.relative_numeric_setting_range(
+        11.5,
+        relative_info,
+        relative_value,
+    ) == (
+        11.75,
+        17.5,
+        0.01,
+        13.1,
+    )
+    assert math.isclose(
+        battery_monitor_settings.relative_setting_offset_from_absolute(11.5, 13.1),
+        1.6,
+    )
 
 
 def test_public_setting_api_is_coerced() -> None:

--- a/tests/test_battery_monitor_settings.py
+++ b/tests/test_battery_monitor_settings.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "victron_mk3"
+    / "battery_monitor_settings.py"
+)
+SPEC = importlib.util.spec_from_file_location("battery_monitor_settings", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+battery_monitor_settings = importlib.util.module_from_spec(SPEC)
+sys.modules["battery_monitor_settings"] = battery_monitor_settings
+SPEC.loader.exec_module(battery_monitor_settings)
+
+
+class FakeDriver:
+    REQUEST_TIMEOUT_SECONDS = 0.1
+
+    def __init__(self, responses: list[bytes] | None = None) -> None:
+        self.responses = responses or []
+        self.requests: list[list[int]] = []
+        self.frames: list[tuple[str, list[int]]] = []
+        self._w_completion = None
+
+    def _send_w_request(self, msg: list[int], completion) -> None:
+        self.requests.append(msg)
+        self._w_completion = completion
+        for response in self.responses:
+            completion(None, response)
+
+    def _send_frame(self, command: str, data: list[int]) -> None:
+        self.frames.append((command, data))
+
+
+class FakeMK3:
+    def __init__(self, driver: FakeDriver | None = None) -> None:
+        self._driver = driver
+
+
+class PublicInfoResponse:
+    supported = True
+    scale = 1
+    offset = 0
+    default_raw = 0
+    minimum_raw = 0
+    maximum_raw = 65330
+    access_level = None
+
+
+class PublicValueResponse:
+    supported = True
+    raw_value = 242
+    value = 0.94921875
+
+
+class PublicMK3:
+    async def send_setting_info_request(self, setting_id: int):
+        return PublicInfoResponse()
+
+    async def send_setting_request(self, setting_id: int):
+        return PublicValueResponse()
+
+    async def send_setting_write_request(self, setting_id: int, value: float):
+        return PublicValueResponse()
+
+
+def test_battery_monitor_enabled_is_based_on_capacity() -> None:
+    assert battery_monitor_settings.battery_monitor_enabled_from_capacity(None) is None
+    assert not battery_monitor_settings.battery_monitor_enabled_from_capacity(0)
+    assert battery_monitor_settings.battery_monitor_enabled_from_capacity(522)
+
+
+def test_read_setting_info_uses_known_metadata_for_battery_monitor_settings() -> None:
+    info = asyncio.run(
+        battery_monitor_settings.read_setting_info(FakeMK3(FakeDriver()), 72)
+    )
+
+    assert info is not None
+    assert info.supported
+    assert info.scale == 1 / 256
+    assert info.offset == 1
+    assert info.minimum == 1 / 256
+    assert info.maximum == 1
+
+
+def test_read_setting_info_parses_short_mode_multi_frame_response() -> None:
+    driver = FakeDriver(
+        [
+            bytes.fromhex("ff588901008a00008b00008c0000"),
+            bytes.fromhex("ff588d32ff"),
+        ]
+    )
+
+    info = asyncio.run(
+        battery_monitor_settings.read_setting_info(FakeMK3(driver), 200)
+    )
+
+    assert driver.requests == [[0x35, 200, 0]]
+    assert info is not None
+    assert info.supported
+    assert info.maximum_raw == 65330
+    assert info.value_from_raw(522) == 522
+
+
+def test_read_setting_reads_scaled_charge_efficiency() -> None:
+    driver = FakeDriver([bytes.fromhex("ff5986f200")])
+    info = battery_monitor_settings.SettingInfo(
+        setting_id=72,
+        supported=True,
+        scale=1 / 256,
+        offset=1,
+        default_raw=255,
+        minimum_raw=0,
+        maximum_raw=255,
+    )
+
+    value = asyncio.run(
+        battery_monitor_settings.read_setting(FakeMK3(driver), 72, info)
+    )
+
+    assert driver.requests == [[0x31, 72, 0]]
+    assert value is not None
+    assert value.supported
+    assert value.raw_value == 242
+    assert value.value == 0.94921875
+
+
+def test_write_setting_sends_write_setting_then_write_data() -> None:
+    driver = FakeDriver([bytes.fromhex("ff59880000")])
+    info = battery_monitor_settings.SettingInfo(
+        setting_id=65,
+        supported=True,
+        scale=0.5,
+        offset=0,
+        default_raw=170,
+        minimum_raw=60,
+        maximum_raw=200,
+    )
+
+    value = asyncio.run(
+        battery_monitor_settings.write_setting(FakeMK3(driver), 65, 90, info)
+    )
+
+    assert driver.frames == [("X", [0x33, 65, 0])]
+    assert driver.requests == [[0x34, 180, 0]]
+    assert value is not None
+    assert value.supported
+    assert value.raw_value == 180
+    assert value.value == 90
+
+
+def test_public_setting_api_is_coerced() -> None:
+    info = asyncio.run(battery_monitor_settings.read_setting_info(PublicMK3(), 64))
+    value = asyncio.run(battery_monitor_settings.read_setting(PublicMK3(), 72))
+    written = asyncio.run(battery_monitor_settings.write_setting(PublicMK3(), 72, 0.95))
+
+    assert info is not None
+    assert info.supported
+    assert info.maximum_raw == 65330
+    assert value is not None and value.value == 0.94921875
+    assert written is not None and written.raw_value == 242

--- a/tests/test_init_source.py
+++ b/tests/test_init_source.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_setup_entry_refreshes_without_blocking_on_first_update() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "victron_mk3"
+        / "__init__.py"
+    ).read_text()
+
+    assert "await coordinator.async_refresh()" in source
+    assert "async_config_entry_first_refresh" not in source

--- a/tests/test_init_source.py
+++ b/tests/test_init_source.py
@@ -11,3 +11,5 @@ def test_setup_entry_refreshes_without_blocking_on_first_update() -> None:
 
     assert "await coordinator.async_refresh()" in source
     assert "async_config_entry_first_refresh" not in source
+    assert "debug_scan_settings" not in source
+    assert "DEBUG_SCAN_MARKER" not in source

--- a/tests/test_number_source.py
+++ b/tests/test_number_source.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_battery_monitor_number_entities_avoid_unsupported_precision_keyword() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "victron_mk3"
+        / "number.py"
+    ).read_text()
+
+    assert "battery_capacity" in source
+    assert "battery_soc_when_bulk_finished" in source
+    assert "battery_charge_efficiency" in source
+    assert "suggested_display_precision" not in source

--- a/tests/test_number_source.py
+++ b/tests/test_number_source.py
@@ -12,4 +12,8 @@ def test_battery_monitor_number_entities_avoid_unsupported_precision_keyword() -
     assert "battery_capacity" in source
     assert "battery_soc_when_bulk_finished" in source
     assert "battery_charge_efficiency" in source
+    assert "dc_input_low_shutdown" in source
+    assert "DC Input Low Shut-down" in source
+    assert "dc_input_low_restart" in source
+    assert "DC Input Low Restart" in source
     assert "suggested_display_precision" not in source

--- a/tests/test_ram_variables.py
+++ b/tests/test_ram_variables.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "victron_mk3"
+    / "ram_variables.py"
+)
+SPEC = importlib.util.spec_from_file_location("ram_variables", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+ram_variables = importlib.util.module_from_spec(SPEC)
+sys.modules["ram_variables"] = ram_variables
+SPEC.loader.exec_module(ram_variables)
+
+
+class FakeDriver:
+    REQUEST_TIMEOUT_SECONDS = 0.1
+
+    def __init__(self, responses: list[bytes] | None = None) -> None:
+        self.responses = responses or []
+        self.requests: list[list[int]] = []
+        self.frames: list[tuple[str, list[int]]] = []
+        self._w_completion = None
+
+    def _send_w_request(self, msg: list[int], completion) -> None:
+        self.requests.append(msg)
+        self._w_completion = completion
+        for response in self.responses:
+            completion(None, response)
+
+    def _send_frame(self, command: str, data: list[int]) -> None:
+        self.frames.append((command, data))
+
+
+class FakeMK3:
+    def __init__(self, driver: FakeDriver | None = None) -> None:
+        self._driver = driver
+
+
+def test_read_ram_variable_info_parses_bit_variable_metadata() -> None:
+    driver = FakeDriver([bytes.fromhex("ff588e02008f0080")])
+
+    info = asyncio.run(
+        ram_variables.read_ram_variable_info(
+            FakeMK3(driver), ram_variables.IGNORE_AC_INPUT_VARIABLE_ID
+        )
+    )
+
+    assert driver.frames == [("A", [1, 0])]
+    assert driver.requests == [[0x36, ram_variables.IGNORE_AC_INPUT_VARIABLE_ID, 0]]
+    assert info is not None
+    assert info.supported
+    assert info.bit == 1
+    assert ram_variables.ram_variable_bool_supported(info)
+
+
+def test_read_ram_variable_reads_bit_backed_boolean_value() -> None:
+    driver = FakeDriver([bytes.fromhex("ff59850200")])
+    info = ram_variables.RamVariableInfo(
+        variable_id=ram_variables.IGNORE_AC_INPUT_VARIABLE_ID,
+        supported=True,
+        bit=1,
+    )
+
+    value = asyncio.run(
+        ram_variables.read_ram_variable(
+            FakeMK3(driver), ram_variables.IGNORE_AC_INPUT_VARIABLE_ID, info
+        )
+    )
+
+    assert driver.frames == [("A", [1, 0])]
+    assert driver.requests == [[0x30, ram_variables.IGNORE_AC_INPUT_VARIABLE_ID]]
+    assert value is not None
+    assert value.supported
+    assert value.raw_value == 2
+    assert value.value == 1
+    assert ram_variables.ram_variable_bool_enabled(value, info)
+
+def test_ram_variable_bool_enabled_supports_bit_and_binary_variables() -> None:
+    bit_info = ram_variables.RamVariableInfo(
+        variable_id=ram_variables.IGNORE_AC_INPUT_VARIABLE_ID,
+        supported=True,
+        bit=1,
+    )
+    binary_info = ram_variables.RamVariableInfo(
+        variable_id=12,
+        supported=True,
+        scale=1,
+        offset=0,
+    )
+
+    assert ram_variables.ram_variable_bool_enabled(
+        ram_variables.RamVariableValue(
+            variable_id=ram_variables.IGNORE_AC_INPUT_VARIABLE_ID,
+            supported=True,
+            raw_value=2,
+        ),
+        bit_info,
+    )
+    assert not ram_variables.ram_variable_bool_enabled(
+        ram_variables.RamVariableValue(
+            variable_id=ram_variables.IGNORE_AC_INPUT_VARIABLE_ID,
+            supported=True,
+            raw_value=0,
+        ),
+        bit_info,
+    )
+    assert ram_variables.ram_variable_bool_enabled(
+        ram_variables.RamVariableValue(variable_id=12, supported=True, raw_value=1, value=1),
+        binary_info,
+    )
+    assert not ram_variables.ram_variable_bool_enabled(
+        ram_variables.RamVariableValue(variable_id=12, supported=True, raw_value=0, value=0),
+        binary_info,
+    )

--- a/tests/test_remote_panel.py
+++ b/tests/test_remote_panel.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "victron_mk3"
+    / "remote_panel.py"
+)
+SPEC = importlib.util.spec_from_file_location("remote_panel", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+remote_panel = importlib.util.module_from_spec(SPEC)
+sys.modules["remote_panel"] = remote_panel
+SPEC.loader.exec_module(remote_panel)
+
+
+def test_mode_with_charger_enabled_uses_pass_through_for_non_charging_inverter_mode() -> None:
+    assert (
+        remote_panel.mode_with_charger_enabled(remote_panel.Mode.ON, False)
+        is remote_panel.Mode.PASS_THROUGH
+    )
+    assert (
+        remote_panel.mode_with_charger_enabled(remote_panel.Mode.PASS_THROUGH, True)
+        is remote_panel.Mode.ON
+    )
+    assert (
+        remote_panel.mode_with_charger_enabled(remote_panel.Mode.CHARGER_ONLY, False)
+        is remote_panel.Mode.OFF
+    )
+
+
+def test_pass_through_mode_maps_to_on_with_charge_disabled() -> None:
+    assert (
+        remote_panel.base_mode_for_remote_panel(remote_panel.Mode.PASS_THROUGH)
+        is remote_panel.Mode.ON
+    )
+    assert remote_panel.disable_charge_for_remote_panel(remote_panel.Mode.PASS_THROUGH)
+    assert not remote_panel.disable_charge_for_remote_panel(remote_panel.Mode.ON)
+
+
+def test_mode_with_disable_charge_maps_on_to_pass_through() -> None:
+    assert (
+        remote_panel.mode_with_disable_charge(remote_panel.Mode.ON, True)
+        is remote_panel.Mode.PASS_THROUGH
+    )
+    assert (
+        remote_panel.mode_with_disable_charge(remote_panel.Mode.CHARGER_ONLY, True)
+        is remote_panel.Mode.CHARGER_ONLY
+    )

--- a/tests/test_sensor_source.py
+++ b/tests/test_sensor_source.py
@@ -11,6 +11,9 @@ def test_sensor_source_exposes_battery_energy_entities_for_energy_dashboard() ->
 
     assert 'key="battery_energy_into"' in source
     assert 'key="battery_energy_out_of"' in source
+    assert 'key="ignore_ac_input_state"' in source
+    assert 'name="Ignore AC Input State"' in source
     assert "SensorDeviceClass.ENERGY" in source
+    assert "SensorDeviceClass.ENUM" in source
     assert "SensorStateClass.TOTAL_INCREASING" in source
     assert "UnitOfEnergy.KILO_WATT_HOUR" in source

--- a/tests/test_sensor_source.py
+++ b/tests/test_sensor_source.py
@@ -17,3 +17,16 @@ def test_sensor_source_exposes_battery_energy_entities_for_energy_dashboard() ->
     assert "SensorDeviceClass.ENUM" in source
     assert "SensorStateClass.TOTAL_INCREASING" in source
     assert "UnitOfEnergy.KILO_WATT_HOUR" in source
+
+
+def test_sensor_source_exposes_signed_battery_power_entity() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "victron_mk3"
+        / "sensor.py"
+    ).read_text()
+
+    assert 'key="battery_charge_discharge_power"' in source
+    assert 'name="Battery Charge Discharge Power"' in source
+    assert "else -data.power.dc_power" in source

--- a/tests/test_sensor_source.py
+++ b/tests/test_sensor_source.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_sensor_source_exposes_battery_energy_entities_for_energy_dashboard() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "victron_mk3"
+        / "sensor.py"
+    ).read_text()
+
+    assert 'key="battery_energy_into"' in source
+    assert 'key="battery_energy_out_of"' in source
+    assert "SensorDeviceClass.ENERGY" in source
+    assert "SensorStateClass.TOTAL_INCREASING" in source
+    assert "UnitOfEnergy.KILO_WATT_HOUR" in source

--- a/tests/test_switch_source.py
+++ b/tests/test_switch_source.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+def test_switch_source_exposes_setting_flag_switches() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "victron_mk3"
+        / "switch.py"
+    ).read_text()
+
+    assert 'key="charge_enabled"' in source
+    assert 'name="Charge Enabled"' in source
+    assert 'key="power_assist"' in source
+    assert 'name="PowerAssist"' in source
+    assert 'key="ups_function"' in source
+    assert 'name="UPS Function"' in source
+    assert 'key="dynamic_current_limiter"' in source
+    assert 'name="Dynamic Current Limiter"' in source
+    assert 'key="weak_ac_input"' in source
+    assert 'name="Weak AC Input"' in source
+    assert "DISABLE_WAVE_CHECK_FLAG_BIT" in source
+    assert "DISABLE_WAVE_CHECK_INVERTED_FLAG_BIT" in source
+    assert "POWER_ASSIST_ENABLED_FLAG_BIT" in source
+    assert "DYNAMIC_CURRENT_LIMITER_ENABLED_FLAG_BIT" in source
+    assert "WEAK_AC_INPUT_ENABLED_FLAG_BIT" in source
+    assert "mode_with_charger_enabled" in source
+    assert "VictronMK3ChargeEnabledSwitchEntity(context)" in source
+    assert "VictronMK3UpsFunctionSwitchEntity(context)" in source
+    assert "VictronMK3SettingFlagSwitchEntity(context, description)" in source


### PR DESCRIPTION
## Summary

This expands the integration from basic remote-panel control into broader battery monitoring, Home Assistant Energy reporting, VE.Bus configuration/state exposure, and clearer Energy dashboard setup guidance.

- add battery monitor support in Home Assistant, including battery state of charge plus battery capacity / bulk-finished SOC / charge-efficiency entities
- add cumulative `Battery Energy Into` and `Battery Energy Out Of` sensors for Home Assistant Energy, restore their totals after restart, and allow startup to complete even when the device is asleep
- add `Battery Charge Discharge Power`, a signed battery-power sensor for Home Assistant's power-based battery view where positive means discharge and negative means charge
- document Home Assistant Energy setup in the README, including grid power selection and Home Battery Storage settings with the correct `Standard` vs `Inverted` direction choice
- add remote-panel `pass_through` support plus a `Charge Enabled` switch so charging can be toggled without dropping inverter / AC pass-through behavior
- expose VE.Bus configuration flags as switches where supported: `UPS Function`, `PowerAssist`, `Dynamic Current Limiter`, and `Weak AC Input`
- add the `Ignore AC Input State` diagnostic sensor, shared helpers for remote-panel / RAM-variable handling, and focused test coverage for the new source wiring

## Why

Upstream currently exposes the core VE.Bus telemetry and remote-panel controls, but it does not surface the extra battery-monitor entities needed for state-of-charge and Home Assistant Energy battery flows, and it does not document the sensor choices needed to wire the Energy dashboard correctly.

This branch fills in those gaps while keeping the existing integration behavior intact and documenting the intended Home Assistant configuration.

## User Impact

Users can now:

- monitor battery state of charge from the VE.Bus battery monitor when the device reports it
- feed cumulative charge/discharge energy into Home Assistant's Energy dashboard battery configuration
- use `Battery Charge Discharge Power` directly for Home Battery Storage power flow with `Direction: Standard`
- use `Battery Power` with `Direction: Inverted` when they want the original non-inverted sensor instead
- use `AC Input Power` for grid power with `Direction: Standard` when the VE.Bus device is measuring the site grid connection point
- enable or disable charging independently of inverter/pass-through availability by using `pass_through` / `Charge Enabled`
- control supported VE.Bus flags directly from Home Assistant instead of switching out to Victron tools for those settings
- inspect whether AC input is currently being ignored through a diagnostic sensor

## Home Assistant Energy setup

The README now includes a dedicated configuration section that documents:

- Grid settings: `AC Input Power` with `Direction: Standard`
- Home Battery Storage: `Battery Energy Into`, `Battery Energy Out Of`, and `Battery Charge Discharge Power` with `Direction: Standard`
- the fallback note that `Battery Power` uses the opposite sign convention and therefore must be configured as `Inverted`

## Testing via HACS

The current testable fork build is published on `main` here:

- `https://github.com/usersaynoso/victron-mk3-hass/tree/main`

To install and test this version through HACS:

1. Open HACS -> Integrations -> the three-dot menu -> Custom repositories.
2. Add `https://github.com/usersaynoso/victron-mk3-hass` as a custom repository.
3. Select `Integration` as the category.
4. Install or Redownload `Victron VE.Bus MK3 Interface Integration` from HACS.
5. Restart Home Assistant.

That installs the code currently published on the fork's `main` branch shown at `https://github.com/usersaynoso/victron-mk3-hass/tree/main`.

## Testing

- `/Users/chris/Git Local/victron-mk3-hass-main/.venv/bin/python -m compileall custom_components tests`
- `/Users/chris/Git Local/victron-mk3-hass-main/.venv/bin/pytest -q`
- deployed to local Home Assistant via `ssh ha`
- verified Home Assistant returned HTTP `200` after restart
- verified the new entity registered as `sensor.victron_mk3_battery_charge_discharge_power`
